### PR TITLE
Mouse button mapping fixed.

### DIFF
--- a/PERQemu/CPU/Instruction.cs
+++ b/PERQemu/CPU/Instruction.cs
@@ -101,9 +101,7 @@ namespace PERQemu.CPU
                         if (Trace.TraceOn)
                             Trace.Log(LogType.Warnings,
                                     "Leap specified, not implemented on the 4K CPU.  Jumped to {0:x4} instead, not {1:x4}",
-                                    NextAddress,
-                                    (ushort)((NotZ) | ((0xff & (~Y)) << 8)) & 0x3fff)
-                            );
+                                    NextAddress, (ushort)((NotZ) | ((0xff & (~Y)) << 8)) & 0x3fff);
 #endif
 #endif
                     }

--- a/PERQemu/Display/Display.cs
+++ b/PERQemu/Display/Display.cs
@@ -231,6 +231,20 @@ namespace PERQemu.Display
             _mouseY = e.Y;
         }
 
+        /// <summary>
+        /// Map the host mouse buttons to the Kriz tablet (passed straight through).
+        /// The GPIB BitPad does its own mapping, since the four-button puck has a
+        /// slightly strange layout.  Here's the chart:
+        ///
+        ///     host        Kriz        BitPad
+        /// 0x8 XButton1    n/a         0x4 blue    or: alt+right
+        /// 0x4 Right       0x4 right   0x8 green
+        /// 0x2 Middle      0x2 middle  0x1 yellow  or: alt+left
+        /// 0x1 Left        0x1 left    0x2 white
+        /// 
+        /// If we emulated the 1-button stylus or the 16-button mega puck we'd have
+        /// to monkey with the mappings, but this is complicated enough...
+        /// </summary>
         void OnMouseDown(object sender, MouseEventArgs e)
         {
             switch (e.Button)
@@ -239,16 +253,16 @@ namespace PERQemu.Display
                     _mouseButton = 0x8;
                     break;
 
-                case MouseButtons.Middle:
-                    _mouseButton = 0x4;
+                case MouseButtons.Right:
+                    _mouseButton = _mouseAltButton ? 0x8 : 0x4;
                     break;
 
-                case MouseButtons.Right:
-                    _mouseButton = _mouseAltButton ? 0x8 : 0x2;
+                case MouseButtons.Middle:
+                    _mouseButton = 0x2;
                     break;
 
                 case MouseButtons.Left:
-                    _mouseButton = _mouseAltButton ? 0x4 : 0x1;
+                    _mouseButton = _mouseAltButton ? 0x2 : 0x1;
                     break;
             }
         }
@@ -378,9 +392,9 @@ namespace PERQemu.Display
             // The following allow special modifiers that make Kriz tablet / BitPadOne tablet
             // manipulation using a standard PC mouse easier:
             //  - If Alt is held down, the Kriz tablet is put into "puck off tablet" mode
-            //    which allows relative mode to work better (though it's still pretty clumsy.)
-            //  - If Ctrl is held down, The Left mouse button simulates Kriz/GPIB button 3 (instead of 1)
-            //    and the Right mouse button simulates GPIB button 4 (instead of 2)
+            //    which allows relative mode to work better (though it's still pretty clumsy)
+            //  - If Ctrl is held down, The Left mouse button simulates Kriz/GPIB middle button
+            //    and the Right mouse button simulates GPIB button 4 (blue; n/a on Kriz)
             //
             if (e.Alt)
             {

--- a/PERQemu/Display/VideoController.cs
+++ b/PERQemu/Display/VideoController.cs
@@ -170,7 +170,7 @@ namespace PERQemu.Display
                         _cursorY = _scanLine;
 #if TRACING_ENABLED
                         if (Trace.TraceOn)
-                            Trace.Log(LogType.Tablet, "Cursor Y set to {0}", _cursorY);
+                            Trace.Log(LogType.Display, "Cursor Y set to {0}", _cursorY);
 #endif
                     }
 
@@ -204,7 +204,7 @@ namespace PERQemu.Display
 
 #if TRACING_ENABLED
                     if (Trace.TraceOn)
-                        Trace.Log(LogType.Tablet, "Cursor X set to {0} (value={1})", _cursorX, value);
+                        Trace.Log(LogType.Display, "Cursor X set to {0} (value={1})", _cursorX, value);
 #endif
                     break;
 

--- a/PERQemu/IO/GPIB/BitPadOne.cs
+++ b/PERQemu/IO/GPIB/BitPadOne.cs
@@ -160,8 +160,8 @@ namespace PERQemu.IO.GPIB
 #if TRACING_ENABLED
                 // For debugging GPIB, too much noise; log these updates on the Kriz channel :-)
                 if (Trace.TraceOn)
-                    Trace.Log(LogType.Tablet, "BitPadOne polled: x={0} y={1} button={2} update={3}",
-                                        x, y, button, _lastUpdate);
+                    Trace.Log(LogType.Tablet, "BitPadOne polled: x={0} y={1} button={2} ({3}) update={4}",
+                                               x, y, button, (char)_buttonMapping[button], _lastUpdate);
 #endif
                 _lastUpdate = 0;
             }
@@ -227,8 +227,8 @@ namespace PERQemu.IO.GPIB
         private bool _talking;
         private bool _listening;
 
-        private readonly byte[] _buttonMapping = { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
-                                                   0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46 };
+        private readonly byte[] _buttonMapping = { 0x30, 0x32, 0x31, 0x33, 0x38, 0x35, 0x36, 0x37,
+                                                   0x34, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46 };
         private const byte _delimiter1 = 0x2c;      // ,
         private const byte _delimiter2 = 0x0a;      // LF
     }


### PR DESCRIPTION
* Instruction.cs: Whoops! Fix typo that prevents compilation when
  SIXTEEN_K is not defined.

* Display.cs: Correct the mouse button mappings! Return the correct
  code for the Kriz (left/mid/right) since the BitPad does its own mapping
  for the four-button puck.

* VideoController.cs: Put back the debug logging now that the mouse
  tracking is working.

* BitPadOne.cs: Correct the button mappings to correspond with fix in
  VideoController.cs.