### PR TITLE
Experiments

### DIFF
--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,27 @@ avoid wasting precious time scrolling to the end. :-)
 
 March, 2024:
 
+    8. All kids love Log.  Rework the debug file rotation since pushing it too
+    hard with a TON of debugging output turnt up kept hard crashing Mono, so I
+    had to address the thread crap (AND NO, IT STILL AIN'T RIGHT) but as long as
+    it grinds out the info I need to pinpoint where the PERQ-2 boot process is
+    binding up I'll call it a win. :-P  Speaking of which, PERQ-Z80 DMA device
+    added, refinements to the Z80 interrupts/DMAC, more bit fiddling to get the
+    finicky floppy boot sequence to complete... inching closer to a potential
+    bare metal POS G install on a PERQ-2/8" Micropolis.  Snapshot to checkpoint
+    progress and for regression testing on Windows/Linux.
+
+    7. Update the PERQ<->Z80 FIFOs to use a regular lock to protect from cross-
+    thread access (like the IOB/CIO latches, the EIO FIFOs talk to both CPU and
+    Z80).  Rework/expand/correct some finer details of the Am9519 and i8237,
+    plus a small EIO fix for the floppy.  Um... attempted floppy boot of a PERQ2
+    Micropolis configuration now makes it to 157 on the DDS.  Holy crap! :-)
+
+    6. Plumbed in most of the i8237 DMA chip and created the special PERQ DMA
+    hardware.  This is a _second_ set of FIFOs that allow memory-to-memory
+    transfers with no CPU intervention.  Add some debug commands to improve
+    visibility into the DMAC internals and hard disk drivers.
+
     5. Micropolis 8" DIB showing signs of life: first little green shoots of
     PERQ-2 support pushing up through the ground.  Am9519 is fielding Z80 IRQs,
     the updated PERQ/Z80 FIFOs seem to be exchanging data, and the VT-100 style
@@ -246,4 +267,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Thu Mar 21 20:41:51 PDT 2024
+Last update: skeezics    Mon Mar 25 21:02:55 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -6,8 +6,26 @@ notes moved to ChangeLog-Old.txt.  New entries here will be added at the top, to
 avoid wasting precious time scrolling to the end. :-)
 
 
+April, 2024:
+
+    1. So, so close to initial floppy boot on the PERQ-2/Micropolis.  Tracking
+    down a really obscure condition where the Z80 doesn't properly ack the final
+    floppy block read when loading the Mboot file, so the PERQ times out (still
+    at DDS 158).  To assist with this, took the time to reconstruct and reformat
+    the entire EIO Z80 ROM source code in PERQemu's debugger format.  (CIO will
+    eventually get this treatment too, since it's a much, much more readable
+    code base than the original old/IOB Z80.)  Check out PROM/eioz80.lst if you
+    want to learn more about the cooperative multitasking the Z80 does to run
+    the low-speed I/O devices on the EIO board.
+
+
 March, 2024:
 
+    9. Fixed some subtle Z80 IRQ and DMAC bugs and now PERQ-Z80 memory transfers
+    through the DMA FIFOs are kinda working.  Floppy boot dies at DDS 158 but it
+    is getting closer... made the boot key press more reliable (EIO Z80 takes a
+    bit longer to start up and it was missing the keypress events).
+    
     8. All kids love Log.  Rework the debug file rotation since pushing it too
     hard with a TON of debugging output turnt up kept hard crashing Mono, so I
     had to address the thread crap (AND NO, IT STILL AIN'T RIGHT) but as long as

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,15 @@ avoid wasting precious time scrolling to the end. :-)
 
 April, 2024:
 
+    3. Floppy boot on PERQ-2/Microp/EIO config reaches 970!  FIFO/interrupt/Z80
+    protocol handling is finicky and making sure the Z80 and PERQ see the right
+    interrupts in only the right situations is still slightly elusive.  The POS
+    init code doesn't seem to handle the floppy boot case very intelligently,
+    since it gets very unhappy when there's no ZBoot file on the boot partition
+    (as is the case booting from single density floppies - not enough room).
+    Sloppy, guys.  Workaround needed for PNX to get around a genuine bug in the
+    VFY MakeVictim test on the PNX2 and PNX3 boot floppies.
+
     2. Added rudimentary Z80 breakpoint support (instruction or memory address
     monitoring).  Used it to find the elusive/undocumented behavior of the DMA
     chip (and diagnosed a bug/weakness in the Z80 semaphore wait/signal code),
@@ -293,4 +302,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Tue Apr  9 21:53:59 PDT 2024
+Last update: skeezics    Sat Apr 20 04:00:19 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,14 @@ avoid wasting precious time scrolling to the end. :-)
 
 April, 2024:
 
+    2. Added rudimentary Z80 breakpoint support (instruction or memory address
+    monitoring).  Used it to find the elusive/undocumented behavior of the DMA
+    chip (and diagnosed a bug/weakness in the Z80 semaphore wait/signal code),
+    and updated the Ethernet drivers (Ether10Mbit and NullEther) to handle the
+    EIO port assignments.  Now the floppy boot gets to DDS 416 and clears the
+    screen but hangs in GPIB intialization; likely the TMS9914 implementation
+    needs a few tweaks for EIO (plus support for DMA "HiVol" operation!).
+
     1. So, so close to initial floppy boot on the PERQ-2/Micropolis.  Tracking
     down a really obscure condition where the Z80 doesn't properly ack the final
     floppy block read when loading the Mboot file, so the PERQ times out (still
@@ -285,4 +293,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Mon Mar 25 21:02:55 PDT 2024
+Last update: skeezics    Tue Apr  9 21:53:59 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -6,6 +6,20 @@ notes moved to ChangeLog-Old.txt.  New entries here will be added at the top, to
 avoid wasting precious time scrolling to the end. :-)
 
 
+March, 2024:
+
+    3. Starting on the i8237 (aka Am9517) DMA controller.
+
+    2. Have put some meat on the bones of the Am9519 and worked out how to route
+    interrupts on the EIO, and it's pretty reasonable.  EIO boots to DDS 013 so
+    basic initializations work; lots of work to get the FIFOs, DMA and hard disk
+    (Micropolis, MFM) going.  Some cleanups to mitigate/fix lingering Execution
+    Controller bugs or annoyances.
+
+    1. A number of small tweaks to get back into PERQ-2.  Studying the Am9519
+    and starting to flesh out the EIO's Z80 interrupt scheme.
+
+
 February, 2024:
 
     4. Small Ethernet, DMA tweaks plus a few guardrails on the Canon driver to
@@ -212,4 +226,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Sun Feb 18 23:02:08 PST 2024
+Last update: skeezics    Mon Mar  4 23:50:55 PST 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -6,7 +6,26 @@ notes moved to ChangeLog-Old.txt.  New entries here will be added at the top, to
 avoid wasting precious time scrolling to the end. :-)
 
 
+June, 2024:
+
+    1. Called away IRL to deal with the whole stupid "not going broke" thing but
+    trying to sneak in development time around the edges.  Merging the interim
+    alpha-/maybe-beta-quality PERQ-2/EIO/Micropolis code into main as a snapshot
+    before leaping into the multiple-drive capable MFM hard disk controller and
+    further PERQ-2 development/refinements.  User Guide way out of date and no
+    pre-built Micropolis disk images included, yet.  Calling this v0.5.8, on the
+    way to a proper v0.6 or v0.7 release when documentation/bugs/MFM catch up.
+
+
 May, 2024:
+
+    6. A few key mapping updates for the PERQ-2 VT100 layout: adding a few extra
+    keys that aren't on the actual PERQ keyboard but are present on modern ones,
+    I figure sending the expected thing rather than having no response at all is
+    the better choice.  I really do want to figure out a clean, simple, cross-
+    platform way to allow setting host-to-PERQ keyboard mappings (at least for a
+    handful of special keys).  For now, hacking UI/SDL/KeyboardMap.cs is the way
+    to change or add your own custom keyboard settings.
 
     5. Some cleanups and small tweaks: fixed Yet Another strange PNX video issue
     so now PNX 3 can drive the display properly.  So close, guys.  So close.
@@ -347,4 +366,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Sun May 26 00:28:49 PDT 2024
+Last update: skeezics    Tue May 28 17:57:16 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,21 @@ avoid wasting precious time scrolling to the end. :-)
 
 May, 2024:
 
+    3. Applied a patch to allow PNX to boot on the 16K CPU without manually
+    hacking around the Vfy microcode bug.  The emulator now patches the Victim
+    test automatically so PNX 2 (and 3) boot without intervention.  Also fixed
+    the Kriz tablet, which on EIO apparently does not invert the data (as it
+    does on IOB/CIO).  Investigating GPIB/BitPadOne problem on EIO and looking
+    at Accent S6 network initialization hanging when the Null Ethernet driver
+    is in use.
+
+    2. Bump to v0.5.8 to celebrate a successful installation of Accent S6 (needs
+    Amendment floppies loaded) and PNX 2 -- both OSes are able to load Z80 code
+    at boot time and execute from RAM.  PNX 2 even sets the clock using the RTC?
+    Still plenty of debugging to do and lots of cleanups and loose ends, but the
+    PERQ-2 support is finally happening!  This paves the way for a ton of fun
+    future projects.
+
     1. PERQ-2/Microp/EIO floppy boot for POS G.6 now reaches 999 and gets to the
     shell prompt!  Weeks of beating my head on single stepping disassembed Qcode
     yielded the "aha!" moment that write-protecting the boot floppy fixes the
@@ -313,4 +328,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Fri May 17 12:20:25 PDT 2024
+Last update: skeezics    Mon May 20 15:44:47 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,17 @@ avoid wasting precious time scrolling to the end. :-)
 
 May, 2024:
 
+    5. Some cleanups and small tweaks: fixed Yet Another strange PNX video issue
+    so now PNX 3 can drive the display properly.  So close, guys.  So close.
+
+    Finally got around to fixing the DDS update in the Console title bar that
+    would glitch out some terminal emulators, removing the awful sleep() hack.
+    Now when POS G boots the poor VM doesn't grind to a snail's pace waiting on
+    the main thread to loop updating the DDS.  Still have to debug why the new
+    PERQ-2 serial keyboard isn't properly transmitting certain control codes,
+    like the SAPPHIRE prefix key.  Hope to have some new PERQ-2 configurations
+    with pre-loaded Micropolis disk images assembled soon for an interim release!
+
     4. Ethernet and GPIB fixes for EIO.  Bitpad tracking now works, and the Null
     and 10Mbit Ethernet drivers are properly returning the MAC address bytes,
     updated and "simplified" for both OIO and EIO.  But do not attempt to reason
@@ -336,4 +347,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Thu May 23 16:00:09 PDT 2024
+Last update: skeezics    Sun May 26 00:28:49 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,14 @@ avoid wasting precious time scrolling to the end. :-)
 
 March, 2024:
 
+    5. Micropolis 8" DIB showing signs of life: first little green shoots of
+    PERQ-2 support pushing up through the ground.  Am9519 is fielding Z80 IRQs,
+    the updated PERQ/Z80 FIFOs seem to be exchanging data, and the VT-100 style
+    keyboard is passing keystrokes through the SIO (even without the i8254 PIT
+    implemented :-).  Have to get the i8237 DMA chip working and hook up the
+    weird PERQ-Z80 DMA so I can attempt a floppy boot and try to format a new
+    8" Micropolis for the first time.  Bump version to v0.5.6 and snapshot.
+
     4. Some random improvements along the way: in POS if you copy a file to RSX:
     and forget to specify the destination filename, PERQemu creates a temp name
     in the default Output directory.  Other minor tweaks and fixes have somehow
@@ -238,4 +246,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Wed Mar 13 02:44:20 PDT 2024
+Last update: skeezics    Thu Mar 21 20:41:51 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,13 +8,25 @@ avoid wasting precious time scrolling to the end. :-)
 
 March, 2024:
 
-    3. Starting on the i8237 (aka Am9517) DMA controller.
+    4. Some random improvements along the way: in POS if you copy a file to RSX:
+    and forget to specify the destination filename, PERQemu creates a temp name
+    in the default Output directory.  Other minor tweaks and fixes have somehow
+    yielded an unexpected performance jump of around 4-5fps on my ancient Mac.
+    Not sure how or why, but I'll take it!  Updated the GPIB controller to take
+    in the two extra Z80 I/O addresses that are unique to the EIO; for now they
+    are no-ops to silence "unhandled write" warnings.
+
+    3. Starting on the i8237 (aka Am9517) DMA controller, and the i8254 PIT
+    (timer chip that replaces the Zilog CTC on EIO).  Minor modifications to let
+    the serial devices and SIO talk to the PIT (using the same interface).  Also
+    a minor update to the GPIB controller for EIO (no new functionality).
 
     2. Have put some meat on the bones of the Am9519 and worked out how to route
     interrupts on the EIO, and it's pretty reasonable.  EIO boots to DDS 013 so
     basic initializations work; lots of work to get the FIFOs, DMA and hard disk
     (Micropolis, MFM) going.  Some cleanups to mitigate/fix lingering Execution
-    Controller bugs or annoyances.
+    Controller bugs or annoyances.  Similarly, small change to the HighResTimer
+    to avoid a silly thing (like the ancient Unix "cron" bug).
 
     1. A number of small tweaks to get back into PERQ-2.  Studying the Am9519
     and starting to flesh out the EIO's Z80 interrupt scheme.
@@ -226,4 +238,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Mon Mar  4 23:50:55 PST 2024
+Last update: skeezics    Wed Mar 13 02:44:20 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -6,6 +6,17 @@ notes moved to ChangeLog-Old.txt.  New entries here will be added at the top, to
 avoid wasting precious time scrolling to the end. :-)
 
 
+May, 2024:
+
+    1. PERQ-2/Microp/EIO floppy boot for POS G.6 now reaches 999 and gets to the
+    shell prompt!  Weeks of beating my head on single stepping disassembed Qcode
+    yielded the "aha!" moment that write-protecting the boot floppy fixes the
+    annoying crash that had stalled the process at LoadZ80 (a red herring).
+    Fixes to the Micropolis driver and additional debugging info.  PNX 3 will
+    require its own video workaround (or modification of the PNX 1/PNX 2 hacks)
+    because they did it _another_ different, non-standard way, hoorah!  Sigh.
+
+
 April, 2024:
 
     3. Floppy boot on PERQ-2/Microp/EIO config reaches 970!  FIFO/interrupt/Z80
@@ -302,4 +313,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Sat Apr 20 04:00:19 PDT 2024
+Last update: skeezics    Fri May 17 12:20:25 PDT 2024

--- a/PERQemu/ChangeLog.txt
+++ b/PERQemu/ChangeLog.txt
@@ -8,6 +8,14 @@ avoid wasting precious time scrolling to the end. :-)
 
 May, 2024:
 
+    4. Ethernet and GPIB fixes for EIO.  Bitpad tracking now works, and the Null
+    and 10Mbit Ethernet drivers are properly returning the MAC address bytes,
+    updated and "simplified" for both OIO and EIO.  But do not attempt to reason
+    with the Ethernet logic or understand how and why the low octets of the MAC
+    are scattered about like the Elemental Stones.  Ethernet is crying out for
+    a refactoring to eliminate some duplicated code, and there is still a ton
+    of work to do here.
+
     3. Applied a patch to allow PNX to boot on the 16K CPU without manually
     hacking around the Vfy microcode bug.  The emulator now patches the Victim
     test automatically so PNX 2 (and 3) boot without intervention.  Also fixed
@@ -328,4 +336,4 @@ February, 2023:
 
 
 ---
-Last update: skeezics    Mon May 20 15:44:47 PDT 2024
+Last update: skeezics    Thu May 23 16:00:09 PDT 2024

--- a/PERQemu/Conf/StorageDevices.db
+++ b/PERQemu/Conf/StorageDevices.db
@@ -61,13 +61,13 @@ done
 # Standard 8" drives
 
 define Disk8Inch Microp21
-description "Micropolis 1222 21MB hard disk"
+description "Micropolis 1202 21MB hard disk"
 geometry Microp21 580 3 24 512 16
 performance M1200 3600 10000 25000 4 96 8 705000
 done
 
 define Disk8Inch Microp35
-description "Micropolis 1223 35MB hard disk"
+description "Micropolis 1203 35MB hard disk"
 geometry Microp35 580 5 24 512 16
 performance M1200
 done

--- a/PERQemu/Conf/perq2-t1.cfg
+++ b/PERQemu/Conf/perq2-t1.cfg
@@ -17,5 +17,4 @@ display portrait
 tablet kriz
 drive 0 floppy
 drive 1 disk8inch
-drive 2 disk8inch
 done

--- a/PERQemu/Configurator/ConfigCommands.cs
+++ b/PERQemu/Configurator/ConfigCommands.cs
@@ -405,6 +405,13 @@ namespace PERQemu.UI
                     // Now make the switch
                     PERQemu.Config.Current.IOBoard = ioType;
                     PERQemu.Config.Changed = true;
+
+                    // If we're switching to EIO, quietly remove the Ether
+                    // option if it's present (avoid spurious warnings)
+                    if (ioType == IOBoardType.EIO)
+                    {
+                        RemoveIOOption(IOOptionType.Ether);
+                    }
                 }
 
                 if (!PERQemu.Config.CheckIO())

--- a/PERQemu/Configurator/Configuration.cs
+++ b/PERQemu/Configurator/Configuration.cs
@@ -291,12 +291,14 @@ namespace PERQemu.Config
                 }
                 sb.AppendLine();
 
-                if ((IOOptionBoard == OptionBoardType.OIO ||
-                     IOOptionBoard == OptionBoardType.Ether3) &&
-                     EtherAddress != 0)
+                if (IOOptionBoard == OptionBoardType.OIO && IOBoard != IOBoardType.EIO && EtherAddress != 0)
                 {
                     sb.AppendLine("    Ethernet:  node " + EtherAddress);
                 }
+                
+                // Todo: for 3Mbit Ethernet, address is a single octet, not the
+                // two-octet low word; will have to be stored separately if we
+                // are ever able to emulate the CMU 3Mbit<->10Mbit gateway config!
             }
 
             // Todo: for PERQ-2 models, backplane serial number

--- a/PERQemu/Controller/ExecCommands.cs
+++ b/PERQemu/Controller/ExecCommands.cs
@@ -42,6 +42,8 @@ namespace PERQemu
             Console.WriteLine("The Z80 {0} running", PERQemu.Sys.IOB.Z80System.IsRunning ? "is" : "is not");
 
             // DEBUG
+            PERQemu.Sys.ShowThreadStatus();
+            PERQemu.Sys.IOB.Z80System.ShowThreadStatus();
             PERQemu.Sys.Display.Status();
             PERQemu.Sys.Mouse.Status();
             PERQemu.Sys.VideoController.Status();

--- a/PERQemu/Controller/ExecutionController.cs
+++ b/PERQemu/Controller/ExecutionController.cs
@@ -149,9 +149,6 @@ namespace PERQemu
 
             Console.WriteLine("Power on requested.");
 
-            // Restart the SDL machinery
-            PERQemu.GUI.InitializeSDL();
-
             // In with the new?
             if (!Initialize(PERQemu.Config.Current))
             {
@@ -173,6 +170,9 @@ namespace PERQemu
                 SetState(RunState.Halted);
                 return;
             }
+
+            // Restart the SDL machinery
+            PERQemu.GUI.InitializeSDL();
 
             // Set the initial state
             SetState(RunState.WarmingUp);

--- a/PERQemu/Controller/ExecutionController.cs
+++ b/PERQemu/Controller/ExecutionController.cs
@@ -412,8 +412,10 @@ namespace PERQemu
             }
             else
             {
-                // throw new InvalidOperationException()
-                Console.WriteLine("Sorry, ya cahnt get theyah from heeyah.");
+                if (current == RunState.Halted)
+                    Console.WriteLine("The PERQ has halted; can only reset or power off.");
+                else
+                    Console.WriteLine("Sorry, ya cahnt get theyah from heeyah.");
             }
 
             Log.Debug(Category.Controller, "Transition result is {0}", State);
@@ -523,6 +525,10 @@ namespace PERQemu
                     new SMKey(RunState.Running, RunState.SingleStep), new List<Transition> {
                         new Transition(() => { SetState(RunState.Paused); }, RunState.Paused),
                         new Transition(() => { SetState(RunState.SingleStep); }, RunState.Paused) }
+                },
+                {
+                    new SMKey(RunState.Running, RunState.Halted), new List<Transition> {
+                        new Transition(() => { SetState(RunState.Halted); }, RunState.Halted) }
                 },
                 {
                     new SMKey(RunState.Running, RunState.Off), new List<Transition> {

--- a/PERQemu/Controller/ExecutionController.cs
+++ b/PERQemu/Controller/ExecutionController.cs
@@ -319,7 +319,7 @@ namespace PERQemu
             var count = (int)context;
             var keycode = (byte)(PERQemu.Sys.IOB.Z80System.IsEIO ? ~_bootChar : _bootChar);
 
-            if (PERQemu.Sys.CPU.DDS < 152 && count < 5)
+            if (PERQemu.Sys.CPU.DDS < 152 && count < 10)
             {
                 if (PERQemu.Sys.IOB.Z80System.IsRunning)
                 {

--- a/PERQemu/Controller/ExecutionController.cs
+++ b/PERQemu/Controller/ExecutionController.cs
@@ -403,12 +403,6 @@ namespace PERQemu
                         }
                     }
                 }
-                else
-                {
-                    // fixme: this shouldn't happen if our state machine is complete... 
-                    // so make this an error or just remove it once finally debugged
-                    Log.Error(Category.Controller, "What, bad steps!? Key {0} yeilded no value!", key);
-                }
             }
             else
             {
@@ -535,7 +529,19 @@ namespace PERQemu
                         new Transition(() => { SetState(RunState.ShuttingDown); }, RunState.Off) }
                 },
                 {
+                    new SMKey(RunState.RunInst, RunState.Paused), new List<Transition> {
+                        new Transition(() => { SetState(RunState.Paused); }, RunState.Paused) }
+                },
+                {
                     new SMKey(RunState.RunInst, RunState.Halted), new List<Transition> {
+                        new Transition(() => { SetState(RunState.Halted); }, RunState.Halted) }
+                },
+                {
+                    new SMKey(RunState.RunZ80Inst, RunState.Paused), new List<Transition> {
+                        new Transition(() => { SetState(RunState.Paused); }, RunState.Paused) }
+                },
+                {
+                    new SMKey(RunState.RunZ80Inst, RunState.Halted), new List<Transition> {
                         new Transition(() => { SetState(RunState.Halted); }, RunState.Halted) }
                 },
                 {

--- a/PERQemu/Controller/HighResolutionTimer.cs
+++ b/PERQemu/Controller/HighResolutionTimer.cs
@@ -154,8 +154,6 @@ namespace PERQemu
             int tag = 0;
             double next = interval;
 
-            Log.Detail(Category.Timer, "Register called, requesters length = " + _requesters.Count);
-
             // Loop to see if we have an existing subscriber with the same
             // period; if so, adjust our new request to fire at the same time,
             // in effect coalescing the two and slightly improving efficiency :-)
@@ -164,7 +162,7 @@ namespace PERQemu
                 if (!_requesters[i].Free && Math.Abs(_requesters[i].Interval - interval) < Tolerance)
                 {
                     next = _requesters[i].NextTrigger;
-                    Log.Detail(Category.Timer, "Coalesced new timer at " + next);
+                    Log.Detail(Category.Timer, "Coalesced new timer at {0}", next);
                     break;
                 }
             }

--- a/PERQemu/Controller/HighResolutionTimer.cs
+++ b/PERQemu/Controller/HighResolutionTimer.cs
@@ -240,7 +240,12 @@ namespace PERQemu
         {
             try
             {
+                // Save our current state; if running, pause, adjust, and restart!
+                bool restart = _requesters[tag].Enabled;
+
+                if (restart) Enable(tag, false);
                 _requesters[tag].Interval = interval;
+                if (restart) Enable(tag, true);
                 Log.Debug(Category.Timer, "Interval for timer {0} now {1}", tag, interval);
             }
             catch

--- a/PERQemu/Controller/HighResolutionTimer.cs
+++ b/PERQemu/Controller/HighResolutionTimer.cs
@@ -211,10 +211,13 @@ namespace PERQemu
             {
                 _requesters[tag].Enabled = doit;
 
-                // Enabling a timer starts the thread if it isn't already running
-                if (doit && !_runTimers)
+                if (doit)
                 {
-                    Start();
+                    // Jump forward to current time
+                    _requesters[tag].NextTrigger = Math.Round(ElapsedHiRes());
+
+                    // Start the timer thread if not already running
+                    if (!_runTimers) Start();
                 }
             }
             catch

--- a/PERQemu/Debugger/Breakpoint.cs
+++ b/PERQemu/Debugger/Breakpoint.cs
@@ -273,6 +273,7 @@ namespace PERQemu.Debugger
         /// </summary>
         public void InitBreakpoints()
         {
+            _opWatchList = new BreakpointList(BreakpointType.OpCode, "QCode", 255);
             _ioWatchList = new BreakpointList(BreakpointType.IOPort, "IO Port", 255);
             _irqWatchList = new BreakpointList(BreakpointType.Interrupt, "CPU Interrupt", 8);
             _memWatchList = new BreakpointList(BreakpointType.MemoryLoc, "Memory Address", PERQemu.Config.Current.MemorySizeInBytes / 2);
@@ -283,8 +284,9 @@ namespace PERQemu.Debugger
 
         public bool BreakpointsEnabled => _masterEnable;
 
-        public BreakpointList WatchedInterrupts => _irqWatchList;
+        public BreakpointList WatchedOpCodes => _opWatchList;
         public BreakpointList WatchedIOPorts => _ioWatchList;
+        public BreakpointList WatchedInterrupts => _irqWatchList;
         public BreakpointList WatchedMemoryAddress => _memWatchList;
         public BreakpointList WatchedMicroaddress => _uinstWatchList;
 
@@ -331,8 +333,9 @@ namespace PERQemu.Debugger
 
         bool _masterEnable;
 
-        BreakpointList _irqWatchList;
+        BreakpointList _opWatchList;
         BreakpointList _ioWatchList;
+        BreakpointList _irqWatchList;
         BreakpointList _memWatchList;
         BreakpointList _uinstWatchList;
 

--- a/PERQemu/Debugger/DebugCommands.cs
+++ b/PERQemu/Debugger/DebugCommands.cs
@@ -1106,13 +1106,6 @@ namespace PERQemu
         }
 
         [Conditional("DEBUG")]
-        [Command("debug dump fifos")]
-        void DumpFifos()
-        {
-            PERQemu.Sys.IOB.Z80System.DumpFifos();
-        }
-
-        [Conditional("DEBUG")]
         [Command("debug dump qcodes")]
         void DumpQcodes()
         {

--- a/PERQemu/Debugger/DebugCommands.cs
+++ b/PERQemu/Debugger/DebugCommands.cs
@@ -24,7 +24,6 @@ using System.Collections.Generic;
 
 using PERQemu.Debugger;
 using PERQemu.Processor;
-using PERQemu.IO;
 
 namespace PERQemu
 {

--- a/PERQemu/Debugger/DebugCommands.cs
+++ b/PERQemu/Debugger/DebugCommands.cs
@@ -962,6 +962,14 @@ namespace PERQemu
             if (CheckSys()) PERQemu.Sys.IOB.Z80System.DumpPortBStatus();
         }
 
+        [Command("debug dump harddisk")]
+        void ShowHardDiskStatus()
+        {
+            if (!CheckSys()) return;
+
+            PERQemu.Sys.IOB.DiskController.DumpStatus();
+        }
+
         [Command("debug dump streamer")]
         void ShowStreamerStatus()
         {

--- a/PERQemu/Debugger/DebugCommands.cs
+++ b/PERQemu/Debugger/DebugCommands.cs
@@ -884,6 +884,10 @@ namespace PERQemu
 
             switch (bp)
             {
+                case BreakpointType.OpCode:
+                    selected.Add(PERQemu.Sys.Debugger.WatchedOpCodes);
+                    break;
+
                 case BreakpointType.IOPort:
                     selected.Add(PERQemu.Sys.Debugger.WatchedIOPorts);
                     break;
@@ -901,6 +905,7 @@ namespace PERQemu
                     break;
 
                 case BreakpointType.All:
+                    selected.Add(PERQemu.Sys.Debugger.WatchedOpCodes);
                     selected.Add(PERQemu.Sys.Debugger.WatchedIOPorts);
                     selected.Add(PERQemu.Sys.Debugger.WatchedInterrupts);
                     selected.Add(PERQemu.Sys.Debugger.WatchedMicroaddress);
@@ -925,6 +930,7 @@ namespace PERQemu
                     action.Callback = OnInterrupt;
                     break;
 
+                case BreakpointType.OpCode:
                 case BreakpointType.IOPort:
                 case BreakpointType.MemoryLoc:
                     action.Callback = OnBreakpoint;

--- a/PERQemu/Debugger/Z80DebugCommands.cs
+++ b/PERQemu/Debugger/Z80DebugCommands.cs
@@ -262,6 +262,13 @@ namespace PERQemu
         #endregion
 
         //[Conditional("DEBUG")]
+        [Command("debug z80 poke")]
+        void PokeZ80Mem(ushort addr = 0x6800, byte val = 0)
+        {
+            PERQemu.Sys.IOB.Z80System.Memory[addr] = val;
+        }
+
+        //[Conditional("DEBUG")]
         [Command("debug dump fifos")]
         [Command("debug z80 dump fifos")]
         void DumpFifos()

--- a/PERQemu/Debugger/Z80DebugCommands.cs
+++ b/PERQemu/Debugger/Z80DebugCommands.cs
@@ -49,11 +49,7 @@ namespace PERQemu
         [Command("debug z80 inst", "Run one Z80 opcode")]
         public void DebugZ80Inst()
         {
-            if (PERQemu.Controller.State <= RunState.Off)
-            {
-                Console.WriteLine("The PERQ is currently turned off.");
-            }
-            else
+            if (CheckSys())
             {
                 PERQemu.Controller.TransitionTo(RunState.RunZ80Inst);
                 PERQemu.Sys.PrintStatus();
@@ -63,7 +59,7 @@ namespace PERQemu
         [Command("debug z80 show registers", "Display contents of the Z80 registers")]
         void ShowZ80State()
         {
-            PERQemu.Sys.IOB.Z80System.ShowZ80State();
+            if (CheckSys()) PERQemu.Sys.IOB.Z80System.ShowZ80State();
         }
 
         // todo: bare bones right now - just display one byte.  expand this to
@@ -71,14 +67,17 @@ namespace PERQemu
         [Command("debug z80 show memory", "Display contents of a given memory location")]
         void ShowZ80Memory(ushort addr)
         {
-            try
+            if (CheckSys())
             {
-                byte value = PERQemu.Sys.IOB.Z80System.Memory[addr];
-                Console.WriteLine($"Address: 0x{addr:x4}  Value: 0x{value:x2}");
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Couldn't read {addr}: {e.Message}");
+                try
+                {
+                    byte value = PERQemu.Sys.IOB.Z80System.Memory[addr];
+                    Console.WriteLine($"Address: 0x{addr:x4}  Value: 0x{value:x2}");
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Couldn't read {addr}: {e.Message}");
+                }
             }
         }
 
@@ -86,14 +85,14 @@ namespace PERQemu
         [Command("debug z80 dump interrupts")]
         void DumpIRQs()
         {
-            PERQemu.Sys.IOB.Z80System.DumpIRQStatus();
+            if (CheckSys()) PERQemu.Sys.IOB.Z80System.DumpIRQStatus();
         }
 
         //[Conditional("DEBUG")]
         [Command("debug z80 dump scheduler queue")]
         void DumpZ80Scheduler()
         {
-            PERQemu.Sys.IOB.Z80System.Scheduler.DumpEvents("Z80");
+            if (CheckSys()) PERQemu.Sys.IOB.Z80System.Scheduler.DumpEvents("Z80");
         }
 
         [Command("debug z80 dump rtc")]

--- a/PERQemu/Debugger/Z80DebugCommands.cs
+++ b/PERQemu/Debugger/Z80DebugCommands.cs
@@ -82,10 +82,25 @@ namespace PERQemu
         }
 
         //[Conditional("DEBUG")]
+        [Command("debug dump fifos")]
+        [Command("debug z80 dump fifos")]
+        void DumpFifos()
+        {
+            PERQemu.Sys.IOB.Z80System.DumpFifos();
+        }
+
+        //[Conditional("DEBUG")]
         [Command("debug z80 dump interrupts")]
         void DumpIRQs()
         {
             if (CheckSys()) PERQemu.Sys.IOB.Z80System.DumpIRQStatus();
+        }
+
+        //[Conditional("DEBUG")]
+        [Command("debug z80 dump dma registers")]
+        void DumpDMA()
+        {
+            if (CheckSys()) PERQemu.Sys.IOB.Z80System.DumpDMAStatus();
         }
 
         //[Conditional("DEBUG")]
@@ -104,7 +119,7 @@ namespace PERQemu
             Console.WriteLine(rtc);
         }
 
-        // todo: rom disassembler, like the perq microcode disassembler?
+        // todo: ram & rom disassembler, like the perq microcode disassembler?
         // todo: i/o port reads - and writes!?
         // todo: interrogate memory, fifos, peripheral controllers & registers, etc.
     }

--- a/PERQemu/Debugger/Z80DebugCommands.cs
+++ b/PERQemu/Debugger/Z80DebugCommands.cs
@@ -18,9 +18,7 @@
 //
 
 using System;
-
-using PERQemu.IO;
-using PERQemu.Debugger;
+using System.Diagnostics;
 
 namespace PERQemu
 {
@@ -68,13 +66,6 @@ namespace PERQemu
             PERQemu.Sys.IOB.Z80System.ShowZ80State();
         }
 
-        //[Conditional("DEBUG")]
-        [Command("debug z80 dump scheduler queue")]
-        void DumpZ80Scheduler()
-        {
-            PERQemu.Sys.IOB.Z80System.Scheduler.DumpEvents("Z80");
-        }
-
         // todo: bare bones right now - just display one byte.  expand this to
         // allow ranges and output options (radix, ascii, etc?)
         [Command("debug z80 show memory", "Display contents of a given memory location")]
@@ -89,6 +80,20 @@ namespace PERQemu
             {
                 Console.WriteLine($"Couldn't read {addr}: {e.Message}");
             }
+        }
+
+        //[Conditional("DEBUG")]
+        [Command("debug z80 dump interrupts")]
+        void DumpIRQs()
+        {
+            PERQemu.Sys.IOB.Z80System.DumpIRQStatus();
+        }
+
+        //[Conditional("DEBUG")]
+        [Command("debug z80 dump scheduler queue")]
+        void DumpZ80Scheduler()
+        {
+            PERQemu.Sys.IOB.Z80System.Scheduler.DumpEvents("Z80");
         }
 
         [Command("debug z80 dump rtc")]

--- a/PERQemu/Docs/HardDisks.txt
+++ b/PERQemu/Docs/HardDisks.txt
@@ -1,0 +1,523 @@
+﻿
+Notes on CIO/EIO Hard Disk Implementations
+==========================================
+
+
+This documents the ongoing development of and many intricacies and secrets of
+PERQemu's hard disk emulation.  It is a work in progress.
+
+
+Some Background and a Wee Rant
+------------------------------
+
+One of the most tragically shortsighted decisions in the PERQ software/firmware
+implementation was the design of the hardware to support _exactly one_ floppy
+and one hard disk, with no provision for multiple drives or even adding other
+types or device geometries (beyond the 12MB SA4004 or 24MB SA4008, which differ
+only in the number of available heads).  When it quickly became clear that a
+single hard disk of insufficient capacity was a massive limitation, the work
+required to extend the OS and libraries was a huge undertaking -- a case study
+in being "penny wise and pound foolish."  Economizing a few bits in the wrong
+places had painful repercussions, severely limiting the expandability of the
+machine.  There were even drives from other manufacturers available as early as
+1981-82 with a compatible SA4000-style interface that could have allowed for a
+transition away from the huge 14" form factor without having to stray down the
+weird proprietary path of adapting the (doomed) Micropolis 1200-series of 8"
+drives.  While it was not entirely wasted effort and did yield marginal capacity
+and performance gains, nobody else made compatible drives and the 8" form factor
+for "personal" workstations was quickly supplanted by 5.25" ST506/MFM drives.
+But the self-inflicted limits in the software support continued (like only
+allowing for 8 disk heads), which precluded obvious and easy future upgrades to
+ESDI, and later SASI/SCSI.  Hindsight, alas.
+
+PERQemu has already been refactored to support almost any geometry of hard disk
+type available in the 1980s through the PERQmedia library.  The goal, initially,
+was to allow emulation of all of the supported types from all the PERQ models.
+This has succeeded, with drivers for the Shugart SA4000 hard drives, Shugart
+SA851 floppy drives and the Archive Sidewinder QIC tape drive completed.  This
+document details the saga of figuring out the 8" and 5.25" interfaces to support
+the PERQ-2 models.  Eventually I plan to unravel the mysteries of emulating the
+interim "CIO Micropolis" hack and even someday adding SMD and GPIB disks.  It
+would be "period appropriate" to develop a SASI or SCSI-I driver, just for fun.
+(Donations and pre-orders gladly accepted. :-)
+
+
+The Shugart SA4000-series
+-------------------------
+
+The original PERQemu support for the Shugart drives, attached to the IOB, is
+the baseline for the new storage architecture.  It comprises the HardDisk class,
+which wraps the PERQmedia StorageDevice with all of the read/write/format and
+seek semantics expected of a typical hard disk, and is sufficiently general that
+the other drive types can all use the same code.
+
+The ShugartDiskController provides the PERQ interface by simulating the IOB's
+state machine semantics and its control and status registers.  Drives of the
+Disk14Inch class are the 12MB SA4004 and 24MB SA4008; the entirely mythical 48MB
+SA4104 is in the StorageDevices database but I haven't yet tried to extend the
+PERQ software to allow its extra 8 heads and doubled capacity to be unlocked.
+
+The Shugart controller is unique in that it works with both IOB (old Z80) and
+CIO (new Z80) PERQ-1 configurations, where the Z80 is used to do buffered seeks
+using the CTC chip.  None of the EIO boards used this strategy, instead building
+seek step hardware onto a separate interface board.
+
+This document mainly focuses on development of the EIO/PERQ-2 disk support, so
+the early Shugart controller is not exhaustively documented here.
+
+
+The Micropolis 1200-series
+--------------------------
+
+The earliest code found mentioning the Micropolis 8" disk support is from 1981.
+It isn't clear what actually got built, with almost no schematics or clear
+documentation to assist with reverse engineering efforts.  I have not uncovered
+any schematics for the early 8" Disk Interface Board (DIB) so software support
+is based solely on the behavior of the microcode.  Even that is rife with gaps,
+contradictions, and unknowns.
+
+For the emulator, two implementations are planned:  the first will model the
+earliest version of the adapter that used the old IOB ports and register setup.
+This was apparently developed on a PERQ-1 prior to any of the POS G releases,
+likely concurrently with the EIO board and the new state machine/DIB hardware.
+This is what I'm calling the "CIO Micropolis" IO board which, while exceedingly
+rare, actually exists.  It may only have support in ICL's release of POS called
+"R4" -- and _maybe_ in early PNX?  In theory this makes it possible to connect
+a single 1200-series drive using the new Z80 firmware from a PERQ-1, although
+I've never seen nor heard any mention of a PERQ-1 configured with an 8" drive
+in lieu of the classic 14" Shugart.
+
+The second and far more well known implementation is for the EIO in PERQ-2 and
+PERQ-2/T1 configurations.  This is currently underway and is beginning to show
+signs of life.  The EIO is much better documented, though numerous conflicting
+versions of the microcode and limited documentation are still proving difficult
+to reconcile.  They literally reversed the definition of status bits or changed
+the enumeration of commands in some cases, so figuring out what is supported by
+the boot ROMs, I/O microcode and operating systems is taking some time.
+
+The PERQ does NOT use the Micropolis 1220 "intelligent controller" board, as it
+turns out.  Although there are numerous mentions throughout the available code
+and scattered documentation to the "1223", the Micropolis DIB is built to drive
+a (single) 1203 disk drive directly.  The 1220 could control up to four "raw"
+1200-series drives, and the DIB claims to support two, but the PERQ can only
+physically accommodate one inside the chassis:
+
+    "None of the PERQ cabinets has enough space for mounting more
+     than one 8" drive internally."
+            -- config.doc Rev 3, Steve Clark 18 Dec 84
+
+That's not strictly true, if you consider swapping out the SA851 floppy drive,
+which has the exact same dimensions as the Micropolis 8" hard disks.  For now,
+though, PERQemu limits all Micropolis configurations to a single disk.  It will
+be fun down the road to try a dual-drive setup to see if it works, and if any
+OS can recognize and use the second drive of this type.
+
+
+The Micropolis 1300-series / MFM drives
+---------------------------------------
+
+The Micropolis 1303 was among the first 5.25" MFM/ST-506 type drives introduced
+with the PERQ-2/T2 model, using a new DIB design.  This will be implemented in
+PERQemu as the "MFMDiskController" class.  It is sufficiently different in 
+subtle but significant ways from the 8" Micropolis DIB to require a separate
+implementation.  Two variants were produced, mainly differing in one PAL and the
+use of one signal line: support for write precompensation as required by some
+drives of the class limited those disks to 8 heads.  The more common variant
+used the RWC line as a fourth head select line.  For the purpose of emulation,
+write precomp is irrelevant; one implementation suffices.  The MFM controller
+has enough data from the disk type to interpret the use of the RWC pin as a head
+select or (effective) no-op automatically.
+
+For PERQ-2/T2 (and T4) configurations, two MFM drives will be supported.  While
+the software has hints that all four drive select lines could be used, there are
+only two physical connectors and room in the case for two drives.  It will be
+interesting to see if there is any OS support for four drives after the basic
+functionality is complete.   Note that while PERQemu doesn't care what make or
+model of disks are attached, it may be necessary (at least under POS) that both
+drives in a dual-disk setup are the same -- documentation hints that mixing and
+matching capacities may not have been well supported?  TBD.
+
+
+Architecture
+============
+
+The PERQ hard disk controller is a state machine built around an Am2910 micro-
+sequencer (same as the main CPU).  THANKFULLY the source code to it has been
+found!  The emulation for EIO is based on the NDSK7 code, which is believed to
+be the most current version.  POS G.6 and Accent S6 source code is the baseline
+for Pascal and microcode support.  Where the docs are vague or flat out wrong,
+the source code is the definitive reference for reverse engineering.
+
+Microcode drives the EIO state machine through a set of registers:  SMCTL is a
+direct set of inputs (5 condition bits and 3 function bits) that affect the
+running state machine.  DSKCTL is a byte that is latched but not interpreted
+by the EIO itself; that byte is clocked into the DIB over the same 50-pin cable
+(JB) that the original Shugart used, with most of the status signals returned
+by the DIB using the same/similar meanings as the original interface.  Status
+bits from the drive are combined with status codes generated by the EIO state
+machine to form a single 11-bit SMSTAT register which can be read by the PERQ.
+The top two bits identify the drive class that's configured/attached.  The bits
+correspond, by sheer coincidence, with the two LSBs of the DeviceType code used
+by the PERQmedia library.  Imagine that.
+
+A 16-byte deep register file is written by the microcode and is read by the
+state machine as part of the controller's support for the PERQ's "logical
+header", and is used during formatting operations.  Like the original Shugart,
+the PERQ uses a custom format for the 8" and 5.25" drives, with 16 "logical
+header" bytes in addition to the 512 data bytes in each block (along with all
+of the usual low-level physical headers, gaps and sector format details that
+are not simulated by PERQemu).  Microcode writes the relevant data into the
+register file, sets up the PERQ DMA, then issues a command to the state machine.
+DMA and interrupts take care of sector transfers and signalling completion.
+
+Like the Archive Sidewinder implementation, the hard disk controller classes
+are the PERQ side of the interface: registers, DMA, interrupts.  The HardDisk
+class wraps the mechanical/media part of the implementation (i.e., the actual
+StorageDevice).  In between (for the 8" and 5.25" drives) is an internal class
+that does the magical translation bits that the DIB does in the real hardware:
+commands issued by the PERQ (through the state machine) must be translated and
+sent to the controller/drive using the "nibble bus" protocol, then reassembled
+and executed to perform reads and writes on the device.
+
+
+Nibble On This
+--------------
+
+The Micropolis and MFM drives use the same physical cabling (a single 50-pin
+ribbon from the front of the EIO board) as the original Shugart design.  Both
+the Micropolis and MFM drive types take 8-bit command bytes, but the SA4000
+interface does not provide a byte-wide bus for transmitting them.  Instead,
+the EIO controller and microcode repurpose the Shugart signals to send drive
+select, register select and "nibble" data to the DIB in two parts, and the DIB
+then reassembles and transmits the command bytes to the drive.  In theory, you
+can set two jumpers on the EIO board and attach any of the supported disks or
+DIBs to the controller; in practice -- and for the purposes of emulation -- 
+each type has its own driver specific to the drive class configured.
+
+The outgoing signal lines for the "nibble bus" are interpreted differently for
+the 8" and 5.25" DIBs, with different boot microcode and OS support.
+
+    Aside:  Another painful irony here is that if 3RCC had OEMed Shugart's
+    own controller board instead of rolling their own (assuming the Shugart
+    board was actually shipping in 1980), hard disk interfacing from the
+    start could have been an 8-bit wide SASI-type interaction and NOT the
+    low-level bit banging that the "raw" interface required.  Sigh.
+
+For the Micropolis DIB, four bit nibbles are reconstituted as drive select,
+cylinder and head select, with the drive handling Restore (seek to track 0),
+Seek, and Fault Clear functions directly.  The State Machine on the EIO (the
+controller class proper) handles all disk block operations.  In the emulator,
+all data is transfered between the system and the drive as full blocks using a
+pseudo-DMA approach.  That is: the block is read or written to/from the under-
+lying storage device in one go, directly to memory, and the response is delayed
+using the Scheduler to simulate the accurate timing of the transaction.  Disk
+geometry and performance specs provided by the PERQmedia library allow accurate
+seek delays, rotational delays, and head settling time to be computed.  This is
+sufficiently convincing that the microcode runs unmodified (even for most very
+low-level operations!).  But the lack of a true DMA implementation means that
+the CPU doesn't ever lose memory cycles to I/O access and runs a bit faster
+than a real PERQ does.  I can live with that...
+
+
+Implementation
+==============
+
+Notes!  Scribbles!  Lunatic ravings of a deranged mind!  Some truly esoteric
+details for posterity, based on the painstaking efforts to unravel the PERQ's
+dark mysteries.
+
+
+Disk Control Port
+-----------------
+
+The bit assignments for DSKCTL<7:0> (port 323/0xd3) are:
+ 
+    DSKCTL<7>:  DriveSelect<0>
+    DSKCTL<6>:  DriveSelect<1>
+    DSKCTL<5>:  BA<0>     \_______  RegSelect bits
+    DSKCTL<4>:  BA<1>     /
+    DSKCTL<3>:  B<3>      \
+    DSKCTL<2>:  B<2>       \______  Nibble bus
+    DSKCTL<1>:  B<1>       /
+    DSKCTL<0>:  B<0>      /
+
+These bits are latched and directly drive the lines on the JB cable to the
+Micropolis DIB.  LD CTRL 2 (enable for the latch) is also the signal over the
+cable (JB20) that triggers the latch on the DIB side.  So those are passed to
+the DIB without interpretation.
+
+It appears the MFM controller moves the DriveSelect<1:0> bits to a different
+registers, moves BA<1:0> to bits 6 & 7 while extending B<5:0>.  So that's neat.
+
+
+State Machine Control & Status Ports
+------------------------------------
+
+The bit assignments for SMCTL<7:0> (port 322/0xd2) are:
+ 
+    SMCTL<7>:   T2 H - Makes CRC errors non-fatal (proposed)
+    SMCTL<6>:   BusEn H - latch DSKCTL<5:0> data into drive control electronics
+    SMCTL<5>:   T H - Enables "DB" interrupt
+    SMCTL<4>:   Interrupts On H - Enable all interrupts to PERQ
+    SMCTL<3>:   Reset L - Reset disk controller when Low; must be set High
+                         before doing any disk operations
+    SMCTL<2>:   F2      \
+    SMCTL<1>:   F1       >--------  Command bits
+    SMCTL<0>:   F0      /
+
+The SMCTL<7:3> bits feed the condition code selector to the Am2910 so the state
+machine can test them; SMCTL<2:0> directly feeds the jump address mux to allow
+external commands to directly affect the program execution (when the 2910 MAP
+pin is asserted).  This is local to the EIO.  Bits <7:3> tend to be described
+consistently, although the "proposed" T2 bit seems to have been implemented by
+POS G, possibly earlier?  It's not clear if that was only specifically asserted
+by test/recovery programs.
+
+Note that SMCTL<5>, the "T" bit, seems to have two completely opposite inter-
+pretations based on which document you read:  sometimes it's "ENable the DB
+interrupt" and sometimes it's used as a DISable flag.  Since most sources agree
+that it's active high, I just have to track down as many possible boot floppies
+and diagnostics and OS images as I can to see what's what.
+
+The F<2:0> bits may require more digging because it seems there are numerous
+conflicting sources about their actual interpretation as well.  This is rather
+problematic, as different sources literally show one command code as Format,
+Read, or Write -- data corruption, anyone?  Sigh.  This has to be resolved from
+POS/Accent, eio*disk.micro, and ndsk7.mas sources.  It even changed from the
+included Oct82 to Feb83 versions of the Rose Quick Guide (Docs directory):
+
+       * EIO *                       * CIO *        DiskDefs
+      Accent S6    Operations       Accent S6       POS G.6
+                    PH LH DB
+    0   Idle         - -- -         Idle            DskIdle
+    1   Format       w  w w         WriteChk        DskRdCheck
+    2   Write        c  w w         Write           DskDiagRead
+    3   CWrite       c cr w         FormatWrite     DskWrCheck
+    4   Fix PH       w -- -         ReadChk         DskWrFirst
+    5   Bread        c  r r         FormatRead      DskFormat
+    6                - -- -         SeekOnly        DskSeek
+    7   Read         c cr r         Reset           DskClear
+
+    - = nop, w = write, c = check, r = read
+
+I'm gonna trash a lot of virtual disks before this is finally worked out...
+
+
+SMSTAT (port 123/0x53) returns 11 bits, SMSTAT<10:0> as follows:
+ 
+    SMSTAT<10>: DiskType<1>     - Device type code determined by
+    SMSTAT<9>:  DiskType<0>     - jumpers on the EIO board
+    SMSTAT<8>:  Index
+
+    SMSTAT<7>:  Unit Ready L    
+    SMSTAT<6>:  On Cylinder L
+    SMSTAT<5>:  Fault L
+
+    SMSTAT<4>:  Seek Error L
+    SMSTAT<3>:  State Machine Interrupt H
+
+    SMSTAT<2>:  Status<2>   \
+    SMSTAT<1>:  Status<1>    >----  Status bits
+    SMSTAT<0>:  Status<0>   /
+
+SMSTAT<3>, SMSTAT<4>, SMSTAT<6>, and SMSTAT<7> also cause an interrupt to PERQ
+when asserted. UnitReady, SMSTAT<7> will also cause an interrupt if de-asserted.
+SMCTL<4> must be High to enable interrupts to PERQ.  It is NOT clear if bit 3
+is meant to be asserted if any _condition_ that would assert an interrupt is
+true, even if interrupts are currently being masked, or if it is only asserted
+WHEN the PERQ hard disk interrupt is asserted.  The former interpretation makes
+a little more sense as it means you could poll the status port without raising
+or clearing the actual interrupt line, but why do that if you could just handle
+the interrupt?  TBD.
+
+The two DiskType<1:0> bits reflect jumpers on the EIO board, AND are mapped to
+the same codes in IO_Unit.pas (POS G) and were the source of the DiskType codes
+in PERQmedia.  OF COURSE there are a number of places where the descriptions are
+slightly different, or, in the case of the actual T2 schematics, bit reversed.
+For emulation, the type bits are initialized to Unused, then are updated when
+the actual storage device is loaded.  It's the little things...
+
+Like the SMCTL function bits, the SMSTAT<2:0> bits are, of course, interpreted
+differently in various places so it is taking some experimentation to work out
+the details.  Naturally, one of the codes (SMSTAT == 1) is completely reversed
+between the Micropolis and MFM (D5Inch) implementations:  it seems to mean
+"Logical Header found" in the latter case, probably checked after the mid-sector
+interrupt" is asserted, but at least some versions of D8Inch interpret that as
+LH _NOT_ found.  Sigh.  I swear I'm not making this up:
+
+    (CIO test code?)            Accent S6                     POS G.6
+    Mdsk.micro:         EioDisk.mic:    Eio5Disk.mic:   DiskDefs    IO_Unit
+    -----------------   -------------   -------------   --------    -------
+0   Done                DskDone         same            DIdle       DskOK
+1   SectorNotFound      DskLHFound      same            DBusy       AddrsErr
+2   PhysicalCRCError    DskDataErr      "not used"      DataCRC     PHCRC
+3   FileNumMismatch     DskPHMismatch   same            same        LHSer
+4   LogBlockMismatch    DskLHMismatch   same            same        LHLB
+5   LogHeaderCRCError   DskBadCmd       same            HeadCRC     LHCRC
+6   DataCRCError        DskPHLHCRC      same            unused!?    DaCRC
+7   Busy                DskECCandCRC    DskDataBlkCRC   unused!?    Busy
+
+DiskDefs THEN goes on -- RIGHT BELOW THE COMMENTS -- to actually implement the
+following structure:
+
+    SMStatus = Packed Record
+        SMSt               : (                { 000007 Bits<2:0> }
+            DIdle, DBusy, DataCRC, PHMismatch, LHMismatch,
+            HeadCRC, AbnormalError, SMError
+            );
+        SMInt              : Boolean;         { 000010 Bit<3> }
+        NotTrk0orNotSker   : Boolean;         { 000020 Bit<4> }
+        NotFault           : Boolean;         { 000040 Bit<5> }
+        NotOnCyl           : Boolean;         { 000100 Bit<6> }
+        NotUnitReady       : Boolean;         { 000200 Bit<7> }
+        IndexMark          : Boolean;         { 000400 Bit<8> }
+        DkType             : ( Dk5Inch,       { 003000 Bits<10:9> }
+                               DkUnused,
+                               Dk14Inch,
+                               Dk8Inch );
+        Unused             : 0..31            { 174000 Bits<15:11> }
+    End;
+
+What. the. hell. guys.
+
+
+Register File
+-------------
+
+The register file is written by setting the pointer (write to port 320 / 0xd0)
+and then writing data to port 321 / 0xd1.  With each store the counter auto-
+increments to the next address.  This replaces the individual ports called out
+by the Shugart/IOB where each byte is addressed directly (and there are fewer
+of them?).
+
+Naturally, there are discrepancies and naming incongruities from microcode to
+the state machine firmware, but it seems that so far the important bits line up?
+Check/reconcile Mdsk.micro, eiofmt.mpls.micro, and dprog.man:
+
+Register numbers for RegPointer:        Disk state machine:
+    constant(zerobyte,       0);        zeroadr:  'C3=0, C4=0, C5=0, C6=0'  !0
+    constant(syncbyte,       1);        syncadr:  'C3=1, C4=0, C5=0, C6=0'  !1
+    constant(Headbyte,       2);        headadr:  'C3=0, C4=1, C5=0, C6=0'  !2
+    constant(Sectorbyte,     3);        sectadr:  'C3=1, C4=1, C5=0, C6=0'  !3
+    constant(Cylinderlow,    4);        cyl1adr:  'C3=0, C4=0, C5=1, C6=0'  !4
+    constant(checkreg2,      5);        lh1adr:   'C3=1, C4=0, C5=1, C6=0'  !5
+    constant(checkreg4,      6);        lh3adr:   'C3=0, C4=1, C5=1, C6=0'  !6
+    constant(checkreg6,      7);        lh5adr:   'C3=1, C4=1, C5=1, C6=0'  !7
+    constant(Cylinderhigh,  10);        cyl2adr:  'C3=0, C4=0, C5=0, C6=1'  !10
+    constant(checkreg1,     11);        lh2adr:   'C3=1, C4=0, C5=0, C6=1'  !11
+    constant(checkreg3,     12);        lh4adr:   'C3=0, C4=1, C5=0, C6=1'  !12
+    constant(checkreg5,     13);        lh6adr:   'C3=1, C4=1, C5=0, C6=1'  !13
+
+PERQemu will likely just ignore the LH check bytes entirely.  The cylinder,
+header and sector bytes are crucial to reads/writes (identify which block to go
+fetch) while the LH bytes are basically ignored since PERQmedia doesn't require
+you to scan each block header as it rotates under the read head. :-)  Now, if I
+were to actually use the scheduler to initiate _sector pulses_ and simulate the
+actual rotational latency of the disk mechanism... heh heh.
+
+OOF.  Sector pulses actually ARE on the cable and were used to drive the state
+machine hardware during header matching.  Can probably simulate that without
+actually generating the scheduler events... generating the mid-sector interrupt
+based purely on RPM/byte timing (i.e., fake it).
+
+Those values come from NDsk7.mas so I'll go with that.  The order of checking
+for LH bytes is obvious so it shouldn't be difficult to determine which ones
+are which.
+
+
+M1200 Protocol
+--------------
+
+Most of this will be buried in the details of the DIB, as commands from the PERQ
+are simply executed directly (unlike the streamer, which actually has to bit-
+bang the interface signals based on hardware timing).  The nibble bus values
+from the EIO will be reassembled and latched in the DIB based on the multi-byte
+command format from the Micropolis documentation:
+
+
+                               !       BA1 BA0    REGISTER
+constant(cylreg,0);            !        0   0     Cylinder (8 LSB)
+constant(hdreg,10);            !        0   1     Head/Cylinder (4 MSB)
+constant(CtlReg,40);           !        1   0     Control Register
+                               !        1   1     Not Used
+
+        /// From the Micropolis documentation:
+        /// BA1  BA0    Register
+        ///  0    0     0 - Unused
+        ///  0    1     1 - Head[3:0] / Cylinder[11:8]
+        ///  1    0     2 - Cylinder[7:0]
+        ///  1    1     3 - Control register
+
+constant(DestCyll, 0);      -> BA0
+constant(BusEN,   10);      -> BUSEN
+constant(DestCylH,20);      -> BA1
+constant(DestCtrl,40);      -> ???
+
+ALL OF THESE THINGS ARE NOT LIKE THE OTHERS.  Geez.  Seriously?  I'm not losing
+my mind.  They really did shuffle the BA bits and meanings around.  Oy vey.
+
+For the 8" DIB, the bits MUST be inverted on the bus?  Because the DRIVE doesn't
+use BA0, the DIB uses that to address the nibble latch, but maybe the DIB FOR WHICH
+THERE ARE NO F*CKING SCHEMATICS inverts the select lines on the drive side.  UGH.
+For emulation purposes we ONLY care what the microcode thinks.
+
+
+IOD         EIO         CABLE       DIB
+        LD D CTRL 2     JB20        LOAD        clocks STEP PALs and other ffs
+7       DRIVE SEL<0>    JB18        BA<1>       with BA0 is latch/PAL selector
+6       DRIVE SEL<1>    JB16        BA<0>       for writing BUS<5:0>
+5       BA<0>           JB24        BUS<5>      becomes D SEL H
+4       BA<1>           JB28        BUS<4>      DIR pin on cable JC34
+3       B<3>            JB8         BUS<3>      RWC pin on cable JC2, RWC L sig
+2       B<2>            JB6         BUS<2>      HS<2> on cable JC4
+1       B<1>            JB4         BUS<1>      HS<1> on cable JC18
+0       B<0>            JB2         BUS<0>      HS<0> on cable JC14
+
+        LD D CTRL 1
+7       T2 BIT          --
+6       BUS ENB         JB26        FORM L      huh?   for MFM THIS is the FORMAT BIT?
+5       T BIT           --
+4       DISK INT ENB    --
+3       P RESET L       --
+2       F<2>            --
+1       F<1>            --
+0       F<0>            --
+
+other cable signals:
+
+        SEEK COMPLETE   JB22        pass through from JC8
+        TRACK 00        JB32        pass through from JC10
+        WRITE FAULT     JB34        pass through from JC12
+        READY L         JB12        pass through from JC22
+        INDEX           JB10        pass through from JC20
+        SECTOR L?       JB14        from SECTOR L sig
+
+        WRITE DATA -    JB40        becomes SYNC NRZ WR DATA
+        WRITE DATA +    JB39
+        WRITE CLK -     JB42        becomes WRITE CLOCK
+        WRITE CLK +     JB43
+        WRITE GATE L    JB30        becomes WRITE H -> WRITE GATE to JC6
+        READ GATE L     JB36        becomes READ GATE
+        READ DATA +     JB48        from READ DATA
+        READ DATA -     JB49        from READ DATA
+        PLO CLOCK +     JB45        from PLO CLOCK
+        PLO CLOCK -     JB46
+
+The DIB itself (at least the 5.25" one) creates the sector pulse, by feeding
+INDEX through its own counter.  some of the DP files illustrate this better.
+
+
+Sector Pulse
+------------
+
+To simulate rotational latencies and synthesize sector pulses, the simplest and
+least costly mechanism is to save a timestamp each time index pulse transitions.
+This lets me compute the time from the last index to the current time and fake
+up a sector pulse (so we don't actually fire those 16-30 times a second).  The
+EIO DIBs use Index from the drive to do exactly this, used for triggering the
+mid-sector interrupt.  (I see no evidence that the original Shugart controller
+did this -- it was an EIO thing only.)
+
+For now I can just split the pre-computed sector delay into two events if the
+mid-sector IRQ is enabled.  Otherwise it'll just fire at the end of a successful
+block read/write/format.

--- a/PERQemu/Docs/Hardware References/EIO_Disk_Quick_Feb83.txt
+++ b/PERQemu/Docs/Hardware References/EIO_Disk_Quick_Feb83.txt
@@ -1,0 +1,913 @@
+
+                                                                  07 Feb 83
+
+
+
+
+
+
+
+
+
+
+
+
+                          Quick Guide to Disk Control
+
+                                 John R.  Rose
+
+
+
+
+
+
+                          Three Rivers Computer, Inc.
+
+                               7  February, 1983
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                 -  1 -
+
+                                                                  07 Feb 83
+
+
+          Overview
+
+          This is a quick guide to  use  of  the  new  disk  controller  as
+     implemented  on  the  EIO  board.   Covered  in  this document are the
+     commands and data sent to the controller, the messages and status bits
+     sent  from  the  controller,  and  a  number  of  hints  and  warnings
+     pertaining to some  peculiarities  of  the  hardware  involved.   This
+     document  covers  only  the  Shugart SA-4000 and Micropolis 1200 drive
+     types.
+
+          ISP notation will be used to  describe  all  control  and  status
+     bits.
+          (not yet fully consistent)
+
+          The  user/programmer  must keep in mind that for the disk to work
+     properly, all parts of  the  system  must  work  together.   The  disk
+     controller  depends  on Memory, DMA, microcode, system code(Pascal/C),
+     disk state machine code, and the drive itself.  If not  all  of  these
+     resources  work,  errors, ranging from straight-forward to bizarre can
+     result.
+
+          There are a number of illustrations that will be integrated  into
+     the final document.
+
+
+
+
+
+
+          Registers
+
+          All  disk types supported by the EIO disk controller are accessed
+     via two 8 bit write only registers and one 11 bit read only  register.
+     The bit assignments, as detailed in the following tables, vary in name
+     and function according  to  the  type  of  disk  in  the  system.   In
+     addition,  there  are five other IOB registers of interest to the disk
+     user.   These  additional  locations  are  the  DMA  Channel   control
+     registers, which are discussed in the section on DMA Setup.
+
+          The  two write registers are called DiSKConTroL and State Machine
+     ConTroL, or DSKCTL and SMCTL.  The IOB adresses  for  these  registers
+     are 323 and 322, respectively.  In PERQ microcode they are defined:
+
+
+
+
+
+
+          Constant(DSKCTL, 323);     !disk mechanical control bits
+          Constant(SMCTL,  322);     !state machine control bits
+
+
+                                 -  2 -
+
+                                                                  07 Feb 83
+
+
+
+          Each  register  contains  8  bits  which  are  registered.   Both
+     registers are cleared by the boot button.  DSKCTL can also be  cleared
+     by software via a bit in SMCTL.
+
+          The bit assignments for DSKCTL<7:0> are:
+
+          BIT         SA-4000                 M1200
+
+          DSKCTL<7>:  Select Drive #2         DriveSelect<0>
+          DSKCTL<6>:  Select Drive #3         DriveSelect<1>
+          DSKCTL<5>:  Direction(1=In, 0=Out)  BA<0>
+          DSKCTL<4>:  FaultClear Low-High-Low BA<1>
+          DSKCTL<3>:  Head<3>                 B<3>
+          DSKCTL<2>:  Head<2>                 B<2>
+          DSKCTL<1>:  Head<1>                 B<1>
+          DSKCTL<0>:  Head<0>                 B<0>
+
+
+               The bit assignments for SMCTL<7:0> are:
+
+          BIT
+
+          SMCTL<7>:  T2 H - Makes CRC errors non-fatal.
+          SMCTL<6>:  SA-4000 - Step H - Low-High-Low causes a disk step
+                     M1200   - BusEn H - used to latch data into drive
+                               control electronics via DSKCTL<5:0>.
+          SMCTL<5>:  T L - Enables "DB" interrupt.
+          SMCTL<4>:  Interrupts On H - Enable all interrupts to PERQ
+          SMCTL<3>:  Reset L - Reset disk controller when Low, must be set
+                               High before doing any disk operations.
+          SMCTL<2>:  F2
+          SMCTL<1>:  F1 - See Data Operation Table
+          SMCTL<0>:  F0
+
+           SMCTL<2:0>       Name       Operations
+
+                                        PH LH DB
+
+                   0        Idle         - -- -
+                   1        Format       w  w w
+                   2        Write        c  w w
+                   3        CWrite       c cr w
+                   4        Fix PH       w  - -
+                   5        Bread        c  r r
+                   6                     -  - -
+                   7        Read         c cr r
+
+              - = nop, w = write, c = check, r = read
+
+
+
+                                 -  3 -
+
+                                                                  07 Feb 83
+
+
+                              Data Operation Table
+
+          The read register is called StateMachineSTATus, or  SMSTAT.   The
+     IOB address of SMSTAT is 123.  In PERQ microcode it would be defined:
+
+           Constant(SMSTAT, 123);      !disk controller status register
+
+          SMSTAT contains 11 bits, SMSTAT<10,0>, assigned as follows:
+
+          SMSTAT<10>          - DiskType<1>
+          SMSTAT<9>           - DiskType<0>
+          SMSTAT<8>           - Index/2
+          SMSTAT<7>           - Unit Ready L
+          SMSTAT<6>           - On Cylinder L
+          SMSTAT<5>           - Fault L
+          SMSTAT<4>    SA4000 - Track 00 L
+                        M1200 - Seek Error L
+          SMSTAT<3>           - State Machine Interrupt H
+          SMSTAT<2>           - Status<2>
+          SMSTAT<1>           - Status<1> See Status<2:0> section
+          SMSTAT<0>           - Status<0>
+
+          SMSTAT<3>,  SMSTAT<4>,  SMSTAT<6>,  and  SMSTAT<7>  also cause an
+     interrupt to PERQ when asserted.   Unit  Ready,  SMSTAT<7>  will  also
+     cause  an  interrupt  if  deasserted.  SMCTL<4> must be High to enable
+     these interrupts to PERQ.
+
+          SMSTAT<10:9> report the type of system disk.  These two bits  are
+     jumper  programed  on  the  IOB  and  can  also  be  read  by the disk
+     controller state machine.  In multiple disk systems, all disk must  be
+     of the same general type.  The Disk Types available are:
+
+
+                           SMSTAT<10:9>          Disk Type
+
+                      11 (3000)             Micropolis M1220/8"
+                      10 (2000)             Shugart SA4000/14"
+                           01 (1000)             Reserved
+                           00 (0000)             Reserved
+
+
+
+
+
+
+
+          Mechanical Operation of SA4000
+
+          The SA4000 drive depends almost entirely on the host computer for
+     the  intelligent  control  of  disk  mechanical  operations.  The only
+
+
+                                 -  4 -
+
+                                                                  07 Feb 83
+
+
+     operation that the disk performs on its own is  the  movement  of  the
+     heads  in  the  direction and for the number of steps specified by the
+     host computer.  All control is open loop, with no  detection  of  disk
+     speed or heads settling.
+
+          Unit Selection
+
+          The first operation to be performed is Unit Select.  This is done
+     by asserting the appropriate Drive Select bit in DSKCTL  High.   After
+     this has been done, the programmer must look for SMSTAT<7> to be Low.
+
+          In the SA4000, the Drive Select bits are not decoded but are used
+     directly to enable drive operations.  Drive addressing  is  done  with
+     jumpers  in  a  patch panel on the drive to connect one of three Drive
+     Select lines to the Disk Select net in the drive  electronics.   There
+     are  three possible drive adresses, 1-3, each with a Drive Select line
+     of its own.  Only one Drive select line should be asserted at a time.
+
+          The PERQ disk  controller  permanently  selects  Drive1  and  can
+     select  Drive2  and Drive3 under program control.  this is to maintain
+     plug   compatibility   with   old   systems.    Thus,   under   normal
+     circumstances,  the  system drive will be Drive1 and Drive Select2 and
+     Drive Select3 should be kept Low.
+
+          If the need for a second system  disk  should  arise,  the  drive
+     address select jumper should be set to Drive2 or Drive3 as desired and
+     the appropriate provisions must be made in the system program.
+
+          If multiple drives are selected, there will be no specific  fault
+     condition  detected.   All  selected  drives  will  perform  the  same
+     mechanical functions as far as possible.  The status  lines  are  open
+     collector and will not have any electrical errors.  All errors must be
+     inferred from the unexpected behavior of the status lines.   The  data
+     and  clock  lines will not work well since they are not open collector
+     and will cause serious data errors.
+
+          Unit Ready
+
+          Unit Ready will go Low when the drive is up  to  speed,  the  PLO
+     clock  has  locked  to  the  servo track, two minutes has elapsed from
+     power-up, and the drive has been selected.
+
+          Any changes in Unit Ready will cause an interrupt to PERQ,  which
+     can  only be cleared by reading SMSTAT.  Selection of a new drive will
+     glitch unit Ready and cause an interrupt.
+
+          Seeking
+
+          The control bits for seeking are Direction and Step.  Direction =
+     High  causes  seeking  toward the disk spindle, Direction = Low causes
+
+
+                                 -  5 -
+
+                                                                  07 Feb 83
+
+
+     seeking toward the disk periphery.  Toggling Step from Low to High  to
+     Low will cause the heads to take one step in the direction specified.
+
+          There  are  two  stepping  modes, buffered and non-buffered.  The
+     buffered mode is normally used.
+
+          Buffered stepping happens when the Step pulses  occur  less  than
+     350  microseconds  apart.  An internal counter counts up as each pulse
+     comes in and counts down as  each  step  is  made.   To  stay  in  the
+     buffered  mode,  the  buffer counter must be kept from getting to zero
+     before the last Step pulse is entered.  Step pulses must be no  closer
+     together than 2 microsecond and must be at least 1 microsecond wide.
+
+          Non-buffered  stepping  happens  when  the buffer counter empties
+     before a new Step pulse is received.  When the counter reaches zero, a
+     timer  is  activated  to  wait  for head settling.  No new Step pulses
+     should be sent until On Cylinder is received.  This  process  is  very
+     slow and should not be used.
+
+          After  the  last  step  has  been  executed, the disk will set On
+     Cylinder to Low.   This  only  means  that  the  last  step  has  been
+     commanded.  It does not mean that the heads have stopped moving! There
+     is no way to tell if the heads have stopped moving.  One must  believe
+     the  SA4000  specification, which says it takes about 20 milliseconds.
+     Waiting for two index marks is usually adequate.
+
+          Drive Select  and  Direction  must  be  held  for  at  least  100
+     nanoseconds  after  the  last step pulse has been sent.  The Seek will
+     complete on its own.  If the drive  is  deselected,  its  On  Cylinder
+     transmitter  will  also  be  deselected and will not report a valid On
+     Cylinder  until  the  drive  is  again  selected.   If  the  drive  is
+     deselected  before a seek is completed, the On Cylinder interrupt will
+     not work correctly.
+
+          The disk drive cannot tell one track  from  another  and  has  no
+     sense  of  location.  The host computer must keep track of the current
+     physical location of the heads.
+          Not much can go wrong with a seek.  In any case, the  SA4000  can
+     not  report  seek  errors.  Therefore, the programmer must assume that
+     all is well if On Cylinder is asserted by the drive.
+
+
+          Head Selection
+
+          Head selection on the SA4000 is very simple.  The programmer must
+     simply present the number of the desired head on the Head<3:0> bits of
+     DSKCTL.   Switching  of  heads  occurs  very  quickly,  in   about   1
+     microsecond.
+
+          A  12 MByte drive has heads 0-3, while a 24 MByte drive has heads
+
+
+                                 -  6 -
+
+                                                                  07 Feb 83
+
+
+     0-7.  No SA4000 drives used by PERQ use heads 10-17.
+
+          There are no status bits associated with correct head  selection.
+     If  a non-existent head is selected, a Fault will occur during writing
+     (WriteGate&NoWriteCurrent).  If this occurs, select a real head, clear
+     the fault, and repeat the operation.
+
+
+          Fault
+
+          Fault,  when asserted Low, will inhibit writing on the disk.  Any
+     write operation that causes a Fault should be repeated after the fault
+     has been cleared by Fault Clear.
+
+          There are five causes of Fault:
+
+             1.  Write gate and no Write Current
+             2.  Write Current and no Write Gate
+             3.  Multiple heads selected
+             4.  Write Gate when not Ready
+             5.  Write Gate and Read Gate
+
+          It is best to reset the controller, do a Restore, and start  over
+     after a Fault.  The sector that caused the Fault should be rewritten.
+
+          Fault Clearing
+
+          In  the  event that a fault should occur, it will be necessary to
+     eliminate the cause of the fault and then to clear the fault latch  by
+     toggling  DSKCTL<4>  from Low to High to Low.  The drive being cleared
+     must be selected.
+
+          Index
+
+          The Index signal provided to PERQ,  SMSTATUS<8>,  is  disk  index
+     pulse divided by two, which is a square wave.  The Index mark is found
+     by a program routine which looks for a transition in the Index bit.
+
+          An Index transition occurs once for every revolution of the disk,
+     every 20.24 milliseconds.
+
+          Index  is  not  used by the disk controller and is not absolutely
+     necessary for disk operation.   It  is  used  for  timing  and  during
+     formatting to place all like numbered sectors on the same radiant.
+
+          Track00
+
+          The  Track00  signal will be Low when the heads are positioned on
+     the most peripheral track, which is customarily called track  0.   The
+     SA4000,  as  mentioned previously, doesn't know and doesn't care about
+
+
+                                 -  7 -
+
+                                                                  07 Feb 83
+
+
+     track numbers.
+
+          Track00 is used during recalibrate procedure to signal  when  the
+     heads have reached a know location, track 0.
+
+          Track00  will  cause an  interrupt when asserted.  This interrupt
+     should be ignored.
+
+          On Cylinder
+
+          On Cylinder will be asserted low after the last step command  has
+     been issued to the head positioner.  It does not mean that the disk is
+     ready for a data transfer.  The heads will not be settled until  about
+     20  milliseconds after On Cylinder has been asserted.  Waiting for two
+     Index marks to go by will allow sufficient head settling time.
+
+          When On Cylinder is asserted, it causes  an  interrupt  to  PERQ.
+     The interrupt can be cleared by Reading SMSTATUS.
+
+          Restore
+
+          The  SA4000  does not have an internal restore function.  Restore
+     to Track00 is done by the host computer.
+
+          The Restore operation is done by stepping the heads outwards  one
+     track  at  a  time  while watching the Track00 bit.  When Track00 goes
+     Low, the heads are at track 0.
+
+
+
+
+
+
+
+
+          Micropolis 1200 Mechanical Functions
+
+
+          The M1200 series of 8 inch disk drives has a built-in intelligent
+     controller  for  handling  disk mechanical operations.  Seeks and head
+     selects are done by telling the  drive  which  cylinder  and  head  is
+     desired.   Other operations, such as restore and fault clear, are also
+     done by the internal controller.
+
+          M1200 to SA4000 Adapter
+
+          The control bus structures  of  the  SA4000  and  the  M1200  are
+     sufficiently  different  that  they cannot be directly substituted for
+     one another.  Yet, they are enough alike that a simple adapter circuit
+     will  allow, with the proper software support, the M1200 type of drive
+
+
+                                 -  8 -
+
+                                                                  07 Feb 83
+
+
+     to be used on an SA4000 controller.  Such an adapter has been built.
+
+          The adapter converts the eight-bit control bus of the M1200 to  a
+     bus  that  is physically compatible with the SA4000 control bus.  This
+     is done by using the Step, Direction, FaultClear, and Head<3:0>  lines
+     of the SA4000 bus to transmit data to the M1200, a nibble at a time.
+
+          The  Adapter  passes the Drive Select bits to all drives that are
+     on the system.  Only the selected  drive  will  respond  to  commands.
+     Seeks,  Head  Selects,  and  Restores  may be overlapped, but only the
+     selected drive will be able to set status bits correctly.
+
+          Command Data Transfer Sequence
+
+          The M1200 requires three control bytes,  Cylinder,  CylHead,  and
+     Control.   The data in these bytes are transferred to registers in the
+     M1200 controller.  Data transfer occurs over the control bus from  the
+     PERQ disc controller to the interface adapter and then on to the M1200
+     controller.
+
+          To transfer a byte to the adapter, BA<0> and BA<1>  must  be  set
+     High.  If this were done by ORing a constant into DSKCTL, the constant
+     would be 60.  Thus, BA := 60.
+
+          With BA = 60, the high four bits of the desired control byte  are
+     put  up  on  the  low  four  bits  of DSKCTL.  After a time, about 340
+     nanoseconds, the BusEn bit in SMCTL is set  high,  latching  the  high
+     four  bits  of  the  control byte on the adapter board.  Next, the low
+     four bits of the control byte are put up  on  the  low  four  bits  of
+     DSKCTL.   After about 340 nanoseconds, BusEn is set low, thus latching
+     the low four bits of the control byte.
+
+          After the control byte has been latched in the adapter,  it  must
+     be  sent  to  the disk drive.  This is done by changing BA<1:0> to the
+     appropriate value.  The constants used for various  control  registers
+     are as follows:
+
+        BA :=  0 - Cylinder<7:0>, the low cylinder bits
+
+        BA := 40 - Head<2:0> and Cylinder<11:10> - the head select bits and
+                   the high bits of cylinder
+
+        BA := 20 - Disk Function<7> - Preamp Gain High
+                   Disk Function<6> - Restore
+                   Disk Function<5> - Not Used
+                   Disk Function<4> - Fault Clear
+                   Disk Function<3> - Offset Minus
+                   Disk Function<2> - Offset Plus
+                   Disk Function<1> - Not Used
+                   Disk Function<0> - Write Gate(not a user bit)
+
+
+                                 -  9 -
+
+                                                                  07 Feb 83
+
+
+
+
+
+
+
+
+           Seek and Head Select
+
+           The Cylinder and Head bits are mixed into two bytes, which  must
+     both  be loaded into the M1223 before either head selection or seeking
+     will occur.  The Seek/Head Select is initiated by loading CylHead.  If
+     there was no change in the cylinder number, no seek will be done.
+
+           If  a  seek and head select, i.e a track select is desired, both
+     CylHead and Cylinder must be loaded.  On Cylinder will  be  deasserted
+     for  a time.  When the seek finishes, On Cylinder will be asserted and
+     PERQ will get an interrupt.  If an error occurs, Seek  Error  will  be
+     asserted and PERQ will get an interrupt.
+
+           If  only  a head select is desired, only CylHead need be loaded.
+     The disk drive will then operate as if a seek were being done,  except
+     that  since  no head movement is involved, the time to completion will
+     be much shorter.
+
+           Seek Error will be asserted if  the  operation  times  out  (500
+     milli- seconds) or if an illegal track address is sent.
+
+           A  Seek  Error  can  be  cleared with a Restore  or by issuing a
+     correct track address, unless there has been a mechanical failure.
+
+           Restore
+
+           Restore is initialized by setting a bit in the Control  Function
+     byte.  These bits are not registered, but are simply gated by BA = 20.
+     To cause a Restore, set Control Function<6> High and present the  data
+     at BA = 20.  The Restore will then commence.
+
+           A  Restore  works  much  like a Seek, except that if it does not
+     work, there is nothing that the programmer can do to recover.
+
+           Fault Clear
+
+           Fault Clear, Control Function<4>, must be handled like  Restore.
+     The  only thing it does is try to clear the Fault latch.  If the cause
+     of the fault is still present, it will have no effect.  Fault Clearing
+     should take place instantaneously.
+
+           It  has  been  observed  that  clearing a fault might cause Seek
+     Error to be asserted.  If this is so, it will be  necessary  to  clear
+     the Seek Error as well, by issuing a valid Seek command.
+
+
+                                 - 10 -
+
+                                                                  07 Feb 83
+
+
+
+           Offset
+
+           To  aid  in  data  recovery, the heads may be moved off the data
+     track center, hopefully away from any error zone  into  an  area  with
+     better data retention.  This is done by setting Control function<2> OR
+     Control Function<3> High.  Offset works best when a  media  defect  is
+     the cause of an error.
+
+           Preamp Gain
+
+           Setting Control Function<7> High will boost the gain on the Read
+     Preamplifier, again to aid in error recovery.
+
+           Write Gate
+
+           Write Gate is not directly under programmer  control.   However,
+     BA  must  be  set  to  20  to enable the drive to write.  Resetting BA
+     during a write  operation has the effect of override the operation.
+
+
+
+
+
+
+           Common Operations
+
+           Data Transfer Operations
+
+           All data transfer operations are the same for all disk types, as
+     there  is no need to make any user-visible changes when going from one
+     disk type to another.
+
+           The possible data transfers are as follows:
+
+           SMCTL<2:0>       Name       Operations
+
+                                        PH LH DB
+
+                   0        Idle         - -- -
+                   1        Format       w  w w
+                   2        Write        c  w w
+                   3        CWrite       c cr w
+                   4        Fix PH       w -- -
+                   5        Bread        c  r r
+                   6                     - -- -
+                   7        Read         c cr r
+
+                    - = nop, w = write, c = check, r = read
+
+
+
+                                 - 11 -
+
+                                                                  07 Feb 83
+
+
+
+            Disk Data Transfers
+
+
+            All  data  transfer  operations  begin at a sector boundary and
+     should end before the next sector boundary.
+
+            Setup of the constant registers and the DMA channel  should  be
+     done before issuing a data transfer command.
+
+
+
+
+
+
+            Data Transfer Basics
+
+            Data  transfers take place between PERQ memory and disk drives,
+     via the PERQ disk controller, which is on the  EIO  board.   Transfers
+     may involve reading and/or writing of data.
+
+            Data can be divided into two general types, constant, which are
+     associated with the Constant Registers and Data, which are  associated
+     with PERQ program memory.
+
+            Constants   are   loaded  into  the  disk  controller  internal
+     registers via the IO Bus and are used to generate  Sync  and  Physical
+     Headers,  as  well  as to look for Sync marks and to check data during
+     reads.  Constants should be loaded before  starting  a  data  transfer
+     operation.
+
+            Data  that  are  stored  on  and  retrieved  from  the disk are
+     transferred to and from main memory via the DMA channel which is under
+     the control of the disk controller.  Data are contained in the Logical
+     Header and the Data Block section of the sector format.
+
+            The data handling circuits of the disk controller  can  combine
+     the  Constants  and  Data  during writing and can separate them during
+     reading.  The disk controller can also compare a constant to the  data
+     being  read  from  the  disk  to  determine  such  things as where the
+     interesting information begins, whether the correct  sector  has  been
+     found, and whether the file segment is the desired one.
+
+            BUSEN MUST BE ASSERTED when doing data transfers with the M1220
+     type disk drive.
+
+           Loading SMCTL with anything during a data  transfer  will  clear
+     READGATE  and  WRITEGATE.   This is an emergency stop feature.  Do not
+     change SMCTL until after the second interrupt.
+
+
+
+                                 - 12 -
+
+                                                                  07 Feb 83
+
+
+           Under normal operating  conditions,  there  are  two  interrupts
+     issued.   It  is not necessary to service the first interrupt.  At the
+     second interrupt, the controller will  wait  for  the  command  to  be
+     zeroed before executing any other commands or going to IDLE.
+
+            The Sector Format
+
+            The  disk  controller  only knows about sectors.  It treats all
+     sectors the same and can tell  them  apart  only  by  comparing  their
+     physical   address   to  reference  data  contained  in  the  constant
+     registers.  The arrangement of the  data  in  each  sector  follows  a
+     rigidly defined scheme, know as the Format.
+
+            The  sector format used by the PERQ disk controller consists of
+     three sections  of  similar  arrangement,  but  of  unequal  size  and
+     function.   These  sections  are the Physical Header (PH), the Logical
+     Header (LH), and Data Block(DB).
+
+            All sections start with a "preamble"  and  a  Sync  mark.   The
+     "preamble"  consists  of  all zeroes, while the Sync mark generally is
+     four zeroes followed by four ones.  The  length  of  the  preamble  is
+     determined by the specifications for the particular type of disk drive
+     being used.  It is of no consequence  to  the  user.   The  Perq  disk
+     controller  can read the Disk Type field of SMSTAT  and can adjust the
+     preamble accordingly.  The Sync mark is determined by what is put into
+     the  Constant  Registers  by  the  programmer.  It must be consistent,
+     otherwise the disk will be unreadable by a controller that isn't given
+     the  correct  Sync  pattern.  At the end of each section is appended a
+     Cyclic Redundancy Check (CRC) which is computed using all  bits  after
+     the  Sync mark.  All write operations update the CRC and it is checked
+     during all read operations.
+
+            The PH contains  the  track  and  sector  information  used  to
+     identify the sector being searched for.  When being written during the
+     Format operation, four byte are appended after the  Sync  mark.   They
+     are:  Cylinder,  CylHead, Sector, and Zero.  When being read, the disk
+     controller compares the Cylinder, CylHead, and Sector bytes that  have
+     been  read  from  the  disk  to  data contained in the similarly maned
+     Constant Registers.  If all three bytes match,  then  the  sector  has
+     been  found  and the data transfer operation will continue.  If Sector
+     is incorrect, the operation will be suspended until  the  next  sector
+     boundary,  where  it  will  begin  again.   If Cylinder or CylHead are
+     incorrect, an error has occurred (wrong track), the operation will  be
+     terminated, and an error message and interrupt to PERQ will be issued.
+
+            The LH is similar to the PH except that the variable data  have
+     have  originated  in  PERQ  memory.   When  writing, Data from the DMA
+     channel are appended  to  data  from  the  Constant  Registers.   When
+     reading, the first six bytes of LH Data may be compared to data stored
+     in the Constant Registers.  If this comparison  is  not  perfect,  the
+
+
+                                 - 13 -
+
+                                                                  07 Feb 83
+
+
+     operation  fails  and an error message and interrupt are sent to PERQ.
+     There are a total of four  combinations  of  operations  that  can  be
+     performed on the LH Data.  The LH Data may be: Written, Read, Checked,
+     or Read and Checked.
+
+            The DB is much like the LH, except  that  the  Data  cannot  be
+     checked, only read and written.
+
+            After  the  data  in each section is appended the CRC.  As each
+     section is written, a new CRC is computed and then appended after  the
+     last  data bit.  During each read operation, the CRC is checked.  If a
+     CRC error occurs, the operation  will  terminate  and  a  message  and
+     interrupt will be sent to PERQ.
+
+            If  a fatal error occurs, an error message will be sent to PERQ
+     via SMSTAT.  Also, an interrupt will be generated.  DSKCTL<4> must  be
+     set  High,  otherwise  the interrupts will be masked.  Furthermore, in
+     the case of a fatal error, the disk controller will perform  no  other
+     operations until SMCTL<2:0> has been set to Idle (0).
+
+            It  is  possible  to chain operations, e.g.  consecutive sector
+     read, by simply reseting Sector and the DMA channel.
+
+            Status Messages
+
+            The Disk Controller can send eight different status messages to
+     PERQ  via  SMSTATUS<2:0>.   These  status  messages  may or may not be
+     accompanied by an interrupt, depending on the state of a data transfer
+     operation.  The valid messages are:
+
+            SMSTATUS<2:0>     Explanation
+
+            0                 No operation in progress
+            1                 Operation in progress, no fatal errors
+            2                 DB CRC error (data recovered)
+            3                 PH address error (fatal)
+            4                 LH data mismatch (fatal)
+            5                 PH/LH CRC error (fatal)
+
+
+            Errors  2,  3,  4, and 5 are considered to be always fatal.  In
+     these cases, the state machine in the disk controller will wait for an
+     IDLE  command.  When the IDLE command is received, the disk controller
+     will reset to its quiescent state and will then accept  new  commands.
+     Clearing SMCTL<4> will also accomplish this.
+
+            After  the  data  transfer  is  finished,  or an error has been
+     properly cleared, the SMSTATUS<2:0> should be 0.
+
+            As there  are  many  possible  combinations  of  data  transfer
+
+
+                                 - 14 -
+
+                                                                  07 Feb 83
+
+
+     operations  and  possible  status  messages,  support  software can be
+     either simple or complex.  Simple code treats Status 0 and 1 as  being
+     OK,  all  other  codes  being  fatal to the operation and thus causing
+     aborts or retries.   Complex  code,  best  written  in  Pascal,  could
+     consider  all possible circumstances and then do just the right thing.
+     This choice is up to the programmer.
+
+            Disk Status must also be considered along with  Disk Controller
+     Status.   In  certain  circumstances, a data operation might appear to
+     have been done correctly, where, in fact, the  disk  drive  might  not
+     have been working.
+
+            When  the  disk  controller  issues  an  interrupt, it will set
+     SMSTATUS<3> high.  This flag was originally meant to indicate that the
+     disk  controller had issued an interrupt, as opposed to the disk drive
+     interrupts.  This was meant to simplify testing for  status.   At  the
+     present  time, SMSTATUS<3> only indicates that the disk controller has
+     issued an interrupt at some time and that it has not yet  returned  to
+     the IDLE state.
+
+            DMA Setup
+
+            In order for a data transfer to work, the PERQ DMA Channel must
+     be set to the desired initial state.  This is done by writing data  to
+     five IOB registers.
+
+            One IOB register is used to select the desired DMA Channel.  To
+     select the correct channel for the  system  disk,  write  5  into  IOB
+     location  300.  This selects the Disk Channel.  The base addresses for
+     the Logical Header and the  DataBlock  may  now  be  loaded  into  the
+     appropriate registers.
+
+            Each  base address is divided into two fields, Low Address (LA)
+     and High Address (HA).  All the bits of  the  LA  and  the  two  least
+     significant  bits  of  HA are combined in the DMA controller to form a
+     quad-aligned physical address that can access any quadword  in  the  2
+     MByte real address space.
+
+            There  are  two base addresses used, one for the Logical Header
+     (L), and one for the Data Block (D).  L and D are identical  as far as
+     the  address  fields  go.   However, the LHA word (Logical Header High
+     Address), contains a four bit field that describes the number of  quad
+     words  that  are in the LH.  This field is LHA<7:4> and is the inverse
+     of the desired quad count for LH.  For example, the normal two quad LH
+     is evoked by setting LHA to 320.
+
+            The  DMA controller is a cyclic device that must be reset after
+     each use if it is desired for it to work in the LH/DB manner, as  used
+     in  the  disk  data transfer.  This reset is accomplished be reloading
+     the four address registers.  For safety, the DMA channel select should
+
+
+                                 - 15 -
+
+                                                                  07 Feb 83
+
+
+     be set as well, unless it is certain that it has not been changed.
+
+            For more detail, refer to the DMA Channel User's Guide.
+
+            Special Notes - Fix PH
+
+            A  new  command  has been implemented, Fix PH, command 4.  This
+     command will rewrite the  PH,  using  the  contents  of  the  Constant
+     Registers,  of the next sector to come along.  To use it properly, the
+     programmer should first run a read of some sort  to  find  the  sector
+     before  the one which is to be fixed.  At the mid-cycle interrupt, the
+     Constant Registers may be reloaded and the Fix PH command be set up to
+     work on the next sector.
+
+            Care  should be taken when using Fix PH, as the controller will
+     rename sector to be what  is  specified  in  the  Constant  Registers.
+     Duplication  of  Physical Addresses could result from not updating the
+     Constant Registers.  A sector might also be  given  an  out  of  range
+     Physical Address.
+
+            Fix  PH  is  intended  for use only when trying to recover from
+     system crashes that have messed up the original format  of  a  sector.
+     Its  main  purpose  is to repair the PH so that file recovery may then
+     proceed.  When used along with other  data  recovery  facilities,  the
+     chances  of  not  be able to recover all or most of a file are greatly
+     diminished.
+
+            Special Notes - Mask CRC Error
+
+            It is now possible to mask PH and LH CRC errors  so  that  data
+     recovery  may  proceed.   This  is done by asserting the T2 bit in the
+     SMCTL byte, SMCTL<7>.
+
+            The main effect of T2 is to make PH an LH CRC errors  non-fatal
+     to  the  data  transfer  operation,  thus  allowing  the  operation to
+     complete.  The read data thus recovered may then be examined  and,  if
+     necessary and/or possible, corrected.
+
+            This  function  is intended for use only when recovering from a
+     system crash or disk failure.  Recovery of user files, in a usable  or
+     fixable form, from the bad disk is thus more likely.
+
+
+
+
+
+
+
+
+
+
+
+                                 - 16 -
+

--- a/PERQemu/Docs/Magic.txt
+++ b/PERQemu/Docs/Magic.txt
@@ -58,6 +58,7 @@
 #
 # .IMD files are a generic floppy imaging format:
 0   string  IMD\040    IMD archived floppy image
+>4  string  1.16:   (version 1.16)
 >4  string  1.18:   (version 1.18)
 #
 # (This barebones definition should be provided elsewhere; included here

--- a/PERQemu/Docs/Video.txt
+++ b/PERQemu/Docs/Video.txt
@@ -264,20 +264,35 @@ still faster than before, and at most it's only used to update 64 lines out of
 Other Stuff
 -----------
 
-In PNX 1 and PNX 2, ICL decided to do things differently.  PNX 1 only programs
-one 40-line vertical blanking band and doesn't set the StartOver bit.  PNX 2
-sets up one 43-line blanking band and sets the StartOver bit, but at the wrong
-time -- not in the band when VSync is enabled, but in the first Active field at
-the top of the screen!  Why, ICL?  Why?  This must work on the hardware, but I
-cannot fathom why they do it this way, when POS, MPOS and Accent, the ROMs and
-all the diagnostic microcode pretty consistently does it the same way.
+In PNX releases 1 through 3 (the versions tested so far), ICL decided to do
+things differently.  PNX 1 only programs one 40-line vertical blanking band and
+doesn't set the StartOver bit.  PNX 2 sets up one 43-line blanking band and sets
+the StartOver bit, but at the wrong time -- not in the band when VSync is 
+enabled, but in the first Active field at the top of the screen!  In PNX 3, they
+switched to issuing two bands like POS does (20 lines, then 23 lines) and set
+VSync in the first one, and StartOver in the second one.  But they don't leave
+VSync set in the second band, which throws off the emulator's state machine.
+
+Why, ICL?  Why?  Somehow all of these crazy variations in the control register
+programming must work on the hardware, but I cannot fathom why they do it this
+way, when POS, MPOS and Accent, the ROMs and all the diagnostic microcode pretty
+consistently does it the same way.
 
 The workaround in place for PNX 1 has been extended slighly to let PNX 2 drive
-the display properly now too, although it has a glitch where the window manager
-background and the left edge of windows looks as if it's shifted by one word --
-like they aren't properly passing a quad-aligned address to the display address
-register?  This isn't a showstopper but looks pretty bad; on the list of quirks
-to investigate and fix before a PNX 2 disk is bundled with the release.
+the display properly now too, while the PNX 3 fix involves simply forcing the
+VSync bit back on when the control register is _cleared_ for the second band.
+(The PNX 3 fix is similar to the Accent S6 glitch where they program a bogus
+value that tries to set ALL the bits, rather than none.  Sigh.)
+
+PNX 2 also has a graphical glitch where the window manager background and the
+left edge of windows looks as if it's shifted by one word -- like they aren't
+properly passing a quad-aligned address to the display address register?  Not
+the case, as it turns out, insofar as RasterOp and the Memory controller ignore
+the low bits on quad fetches so even if PNX Rop passes mis-aligned addresses
+the hardware and the emulator clear the two LSBs.  This isn't a showstopper as
+it only affects painting the background and not the contents of windows, but it
+looks pretty bad; it's on the list of quirks to investigate and hopefully fix
+before a PNX 2 disk is bundled with the release.
 
 
 The first four CursorFunctions just show the cursor over a blank screen.  This
@@ -288,7 +303,9 @@ to see what happens on the real hardware.  Rip in the fabric of spacetime?
 
 Landscape works!  Though there were only around a dozen PERQ-1s ever made with
 special 1MB landscape memory boards, POS G and Accent S6 both can detect and
-use the landscape display when the CIO Z80 is selected.
+use the landscape display when the CIO Z80 is selected.  It seems that any OS
+supporting the PERQ-2 has landscape support, although it hasn't been extensively
+tested yet.
 
 
 Note that the "CRT signals" register bit for LandscapeDisplay is inverted
@@ -307,4 +324,4 @@ rendered by Windows (on a Sun-branded 23" display using the same panel).  Sigh.
 
 
 ---
-Last update: skeezics    Mon Jul 24 03:09:26 PDT 2023
+Last update: skeezics    Sun May 26 00:28:49 PDT 2024

--- a/PERQemu/Emulator/CPU/CPU.cs
+++ b/PERQemu/Emulator/CPU/CPU.cs
@@ -536,6 +536,13 @@ namespace PERQemu.Processor
                     _incrementBPC = true;           // Increment BPC at start of next cycle
 
                     Log.Debug(Category.OpFile, "NextOp read from BPC[{0:x1}]={1:x2}", BPC, amux);
+#if DEBUG
+                    // Watched Qcode?
+                    if (_system.Debugger.WatchedOpCodes.IsWatched(amux))
+                    {
+                        _break = _system.Debugger.WatchedOpCodes.BreakpointReached(amux);
+                    }
+#endif
                     break;
 
                 case AField.IOD:

--- a/PERQemu/Emulator/CPU/CPU.cs
+++ b/PERQemu/Emulator/CPU/CPU.cs
@@ -720,7 +720,7 @@ namespace PERQemu.Processor
                             {
                                 // This often appears during boot/testing and is harmless in that
                                 // case; turn off these alerts in Release builds to reduce noise
-                                Log.Warn(Category.OpFile, "LoadOp called in wrong cycle?");
+                                Log.Debug(Category.OpFile, "LoadOp called in wrong cycle");
                             }
 #endif
 

--- a/PERQemu/Emulator/CPU/CPUBoard.cs
+++ b/PERQemu/Emulator/CPU/CPUBoard.cs
@@ -174,12 +174,14 @@ namespace PERQemu.Processor
                 _stopAsyncThread = true;
                 _system.Halt(e);
             }
+            finally
+            {
+                Log.Debug(Category.Controller, "[CPU thread stopped]");
+                _heartbeat.Enable(false);
 
-            Log.Debug(Category.Controller, "[CPU thread stopped]");
-            _heartbeat.Enable(false);
-
-            // Detach
-            PERQemu.Controller.RunStateChanged -= OnRunStateChange;
+                // Detach
+                PERQemu.Controller.RunStateChanged -= OnRunStateChange;
+            }
         }
 
         /// <summary>

--- a/PERQemu/Emulator/CPU/CPUBoard.cs
+++ b/PERQemu/Emulator/CPU/CPUBoard.cs
@@ -231,8 +231,8 @@ namespace PERQemu.Processor
             if (_asyncThread != null)
             {
                 Console.WriteLine("CPU thread is ID {0}, status {1}",
-                                  Thread.CurrentThread.ManagedThreadId,
-                                  Thread.CurrentThread.ThreadState);
+                                  _asyncThread.ManagedThreadId,
+                                  _asyncThread.ThreadState);
             }
         }
 

--- a/PERQemu/Emulator/CPU/ControlStore.cs
+++ b/PERQemu/Emulator/CPU/ControlStore.cs
@@ -128,6 +128,21 @@ namespace PERQemu.Processor
                     }
 
                     _microcodeCache[addr] = new Instruction(word, addr);
+
+                    // 
+                    // PNX VFY Bug patch
+                    //      Look for the very specific signature of the 16K CPU
+                    //      Victim test bug and apply the simple fix.
+                    //
+                    if (addr == 0x807 && word == 0x0000c0357083)
+                    {
+                        if (_microcode[0x806] == 0x1241d380080e)
+                        {
+                            Log.Info(Category.Emulator, "** PNX VFY Microcode bug detected, applying workaround **");
+                            _microcodeCache[addr].CND = Condition.True;
+                            _microcodeCache[addr].JMP = JumpOperation.Next;
+                        }
+                    }
                 }
 
                 return _microcodeCache[addr];

--- a/PERQemu/Emulator/CPU/RasterOp.cs
+++ b/PERQemu/Emulator/CPU/RasterOp.cs
@@ -26,65 +26,6 @@ using PERQemu.Memory;
 
 namespace PERQemu.Processor
 {
-    enum Direction
-    {
-        LeftToRight,
-        RightToLeft
-    }
-
-    enum Function
-    {
-        Insert = 0,
-        InsertNot,
-        And,
-        AndNot,
-        Or,
-        OrNot,
-        Xor,
-        Xnor
-    }
-
-    enum Phase
-    {
-        Begin = 0,
-        Mid,
-        End,
-        BeginEnd,
-        XtraSource,
-        FirstSource,
-        EndClear,
-        BeginEndClear,
-        Done
-    }
-
-    enum State
-    {
-        Idle = 0,
-        DestFetch,
-        SrcFetch,
-        Off
-    }
-
-    enum EdgeStrategy
-    {
-        NoPopNoPeek = 0,
-        NoPopPeek,
-        PopNoPeek,
-        PopPeek,
-        Unknown = 7
-    }
-
-    [Flags]
-    enum CombinerFlags
-    {
-        Invalid = 0x00,         // word not properly initialized (debugging)
-        DontMask = 0x01,        // pass word unmodified; beginning of scan line
-        LeftEdge = 0x02,        // word contains a left edge
-        RightEdge = 0x04,       // word contains a right edge
-        Both = 0x06,            // word contains both edges (shortcut)
-        FullWord = 0x08,        // use all 16 bits
-        Leftover = 0x10         // pass word; end of scan line
-    }
 
     public enum MulDivCommand
     {
@@ -95,47 +36,12 @@ namespace PERQemu.Processor
     }
 
     /// <summary>
-    /// A memory word in the RasterOp datapath, augmented with debugging info
-    /// (tracks the source address of a given word).
-    /// </summary>
-    struct ROpWord
-    {
-        public ROpWord(int addr, int idx, ushort val)
-        {
-            Address = addr;
-            Index = idx;
-            Data = val;
-            Mask = CombinerFlags.Invalid;
-        }
-
-        public void Clear()
-        {
-            Address = 0;
-            Index = 0;
-            Data = 0;
-            Mask = CombinerFlags.Invalid;
-        }
-
-        public override string ToString()
-        {
-            return string.Format("Addr={0:x6} Idx={1} Data={2:x4} Mask={3}",
-                                 Address, Index, Data, Mask);
-        }
-
-        public int Address;
-        public int Index;
-        public ushort Data;
-        public CombinerFlags Mask;
-    }
-
-    /// <summary>
     /// Implements the PERQ's RasterOp hardware pipeline.  Works with the
     /// RasterOp microcode to feed quad words through the shifter/combiner
     /// to move rectangular regions of memory very quickly.
     /// </summary>
     public sealed class RasterOp
     {
-
         static RasterOp()
         {
             _rdsTable = new CombinerFlags[512];     // 9 bit index
@@ -1073,6 +979,101 @@ namespace PERQemu.Processor
         bool _ropDebug;
 #endif
         #endregion
+
+
+        /// <summary>
+        /// A memory word in the RasterOp datapath, augmented with debugging info
+        /// (tracks the source address of a given word).
+        /// </summary>
+        struct ROpWord
+        {
+            public ROpWord(int addr, int idx, ushort val)
+            {
+                Address = addr;
+                Index = idx;
+                Data = val;
+                Mask = CombinerFlags.Invalid;
+            }
+
+            public void Clear()
+            {
+                Address = 0;
+                Index = 0;
+                Data = 0;
+                Mask = CombinerFlags.Invalid;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("Addr={0:x6} Idx={1} Data={2:x4} Mask={3}",
+                                     Address, Index, Data, Mask);
+            }
+
+            public int Address;
+            public int Index;
+            public ushort Data;
+            public CombinerFlags Mask;
+        }
+
+        enum Direction
+        {
+            LeftToRight,
+            RightToLeft
+        }
+
+        enum Function
+        {
+            Insert = 0,
+            InsertNot,
+            And,
+            AndNot,
+            Or,
+            OrNot,
+            Xor,
+            Xnor
+        }
+
+        enum Phase
+        {
+            Begin = 0,
+            Mid,
+            End,
+            BeginEnd,
+            XtraSource,
+            FirstSource,
+            EndClear,
+            BeginEndClear,
+            Done
+        }
+
+        enum State
+        {
+            Idle = 0,
+            DestFetch,
+            SrcFetch,
+            Off
+        }
+
+        enum EdgeStrategy
+        {
+            NoPopNoPeek = 0,
+            NoPopPeek,
+            PopNoPeek,
+            PopPeek,
+            Unknown = 7
+        }
+
+        [Flags]
+        enum CombinerFlags
+        {
+            Invalid = 0x00,         // word not properly initialized (debugging)
+            DontMask = 0x01,        // pass word unmodified; beginning of scan line
+            LeftEdge = 0x02,        // word contains a left edge
+            RightEdge = 0x04,       // word contains a right edge
+            Both = 0x06,            // word contains both edges (shortcut)
+            FullWord = 0x08,        // use all 16 bits
+            Leftover = 0x10         // pass word; endscan line
+        }
 
         // Can't reference the protected _memory from CPU parent class?
         MemoryBoard _memory;

--- a/PERQemu/Emulator/IO/CIO.cs
+++ b/PERQemu/Emulator/IO/CIO.cs
@@ -91,7 +91,8 @@ namespace PERQemu.IO
         }
 
         /// <summary>
-        /// Writes a word to the given I/O port.
+        /// Writes a word to the given I/O port.  Same as IOB, with one extra
+        /// port for the Micropolis.
         /// </summary>
         public override void IOWrite(byte port, int value)
         {

--- a/PERQemu/Emulator/IO/CIO.cs
+++ b/PERQemu/Emulator/IO/CIO.cs
@@ -85,8 +85,7 @@ namespace PERQemu.IO
                     return _z80System.ReadData();
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled CIO Read from port {0:x2}", port);
-                    return 0xffff;
+                    throw new UnhandledIORequestException(port);
             }
         }
 
@@ -145,8 +144,7 @@ namespace PERQemu.IO
                     break;
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled CIO Write to port {0:x2}, data {1:x4}", port, value);
-                    break;
+                    throw new UnhandledIORequestException(port, value);
             }
         }
 

--- a/PERQemu/Emulator/IO/DMARegisters.cs
+++ b/PERQemu/Emulator/IO/DMARegisters.cs
@@ -1,0 +1,235 @@
+﻿//
+// DMARegisters.cs - Copyright (c) 2006-2024 Josh Dersch (derschjo@gmail.com)
+//
+// This file is part of PERQemu.
+//
+// PERQemu is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// PERQemu is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PERQemu.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+
+using PERQemu.Processor;
+
+namespace PERQemu.IO
+{
+    /// <summary>
+    /// A superset of the DMA channel descriptions for IOB/CIO and EIO.
+    /// </summary>
+    public enum ChannelName
+    {
+        Unused = 0,
+        uProc = 1,
+        HardDisk = 2,
+        Network = 3,
+        NetXmit = 3,
+        ExtA = 4,
+        ExtB = 5,
+        NetRecv = 6,
+        Idle = 7
+    }
+
+    public delegate void LoadRegisterDelegate(ChannelName chan, int value);
+
+    /// <summary>
+    /// A common class to handle the DMA registers on the IO bus.
+    /// </summary>
+    /// <remarks>
+    /// The PERQ's DMA strategy is distributed across the CPU, MEM and IO slots,
+    /// but for emulation purposes we simply provide a common way to access the
+    /// registers used to program the transfers -- the device implementations
+    /// that use DMA (hard disk, Ethernet, Canon, etc) don't have to manage any
+    /// of that themselves.  At some point the DMA could/should actually request
+    /// cycles from the CPU, implementing the actual RQST/GRANT protocol and
+    /// executing memory cycles, pre-empting the processor, respecting the
+    /// microcode "H" bit, etc.  It'd make for a much more accurate experience,
+    /// but that little touch of extra realism is likely a massive can of worms
+    /// to try to debug. :-)  For now we fake it (pretty convincingly).
+    /// </remarks> 
+    public class DMARegisterFile
+    {
+        public DMARegisterFile()
+        {
+            _portToChannelAction = new Dictionary<byte, LoadRegisterDelegate>();
+
+            _channels = new DMAChannel[] {
+                new DMAChannel(ChannelName.Unused),
+                new DMAChannel(ChannelName.uProc),
+                new DMAChannel(ChannelName.HardDisk),
+                new DMAChannel(ChannelName.NetXmit),
+                new DMAChannel(ChannelName.ExtA),
+                new DMAChannel(ChannelName.ExtB),
+                new DMAChannel(ChannelName.NetRecv),
+                new DMAChannel(ChannelName.Idle)
+            };
+        }
+
+        public void Clear()
+        {
+            for (var i = 0; i < _channels.Length; i++)
+            {
+                _channels[i].DataAddr.Value = 0;
+                _channels[i].HeaderAddr.Value = 0;
+            }
+        }
+
+        public void Assign(byte dataHi, byte dataLo, byte hdrHi, byte hdrLo)
+        {
+            // Four actions for every address pair
+            _portToChannelAction.Add(dataHi, LoadDataHigh);
+            _portToChannelAction.Add(dataLo, LoadDataLow);
+            _portToChannelAction.Add(hdrHi, LoadHeaderHigh);
+            _portToChannelAction.Add(hdrLo, LoadHeaderLow);
+
+            Log.Info(Category.DMA, "DMA mapping assigned for ports {0:x}, {1:x}, {2:x}, {3:x}",
+                                    dataHi, dataLo, hdrHi, hdrLo);
+        }
+
+        public void LoadRegister(ChannelName chan, byte port, int value)
+        {
+            LoadRegisterDelegate doit;
+
+            if (_portToChannelAction.TryGetValue(port, out doit))
+            {
+                doit(chan, value);
+                return;
+            }
+
+            Log.Warn(Category.DMA, "Could not load DMA register 0x{0:2x}, delegate not found!", port);
+        }
+
+        public void LoadDataHigh(ChannelName chan, int value)
+        {
+            _channels[(int)chan].DataAddr.Hi = ~value;
+            Log.Debug(Category.DMA, "{0} data buffer addr (high) set to {1:x}", chan, value);
+        }
+
+        public void LoadDataLow(ChannelName chan, int value)
+        {
+            _channels[(int)chan].DataAddr.Lo = (ushort)value;
+            Log.Debug(Category.DMA, "{0} data buffer addr (low) set to {1:x4}", chan, value);
+        }
+
+        public void LoadHeaderHigh(ChannelName chan, int value)
+        {
+            _channels[(int)chan].HeaderAddr.Hi = ~value;
+            Log.Debug(Category.DMA, "{0} header buffer addr (high) set to {1:x}", chan, value);
+
+            // If EIO header count is bits <7:4> of this word (irrelevant for IOB)
+            _channels[(int)chan].HeaderCount = (byte)(~(value >> 4) & 0x0f);
+        }
+
+        public void LoadHeaderLow(ChannelName chan, int value)
+        {
+            _channels[(int)chan].HeaderAddr.Lo = (ushort)value;
+            Log.Debug(Category.DMA, "{0} header buffer addr (low) set to {1:x4}", chan, value);
+        }
+
+        public int GetDataAddress(ChannelName chan)
+        {
+            return Unfrob(_channels[(int)chan].DataAddr);
+        }
+
+        public int GetHeaderAddress(ChannelName chan)
+        {
+            return Unfrob(_channels[(int)chan].HeaderAddr);
+        }
+
+        public byte GetHeaderCount(ChannelName chan)
+        {
+            return _channels[(int)chan].HeaderCount;
+        }
+
+        /// <summary>
+        /// Unfrob a DMA address like the hardware do.  This is common to IOB
+        /// and CIO, and any OIO device that uses DMA.  For EIO, the hardware
+        /// doesn't invert the high bits, but it does use one nibble to encode
+        /// the (inverted) word count for header transfers.
+        /// </summary>
+        /// <remarks>
+        ///                                 ! Explained:
+        /// tmp := 176000;                  ! Need to compliment upper 6 bits
+        ///                                 ! of buffer address. The hardware
+        ///                                 ! has an inversion for the upper
+        ///                                 ! 10 bits of the 20 bit address.
+        /// Buffer xor tmp, IOB(LHeadAdrL); ! Send lower 16 bits of logical
+        ///                                 ! header address to channel ctrl.
+        /// not 0, IOB(LHeadAdrH);          ! Send higher 4 bits of logical
+        ///                                 ! header address to channel ctrl.
+        ///                                 ! Remember, these bits are inverted.
+        /// </remarks>
+        public virtual int Unfrob(ExtendedRegister addr)
+        {
+            int unfrobbed;
+
+            if (PERQemu.Sys.IOB.IsEIO)
+            {
+                // For EIO, only the upper bits are inverted
+                unfrobbed = (~addr.Hi & 0x0f0000) | addr.Lo;
+            }
+            else
+            {
+                // Hi returns the upper 4 or 8 bits shifted; Lo needs to be unfrobbed
+                unfrobbed = addr.Hi | (~(0x3ff ^ addr.Lo) & 0xffff);
+            }
+            Log.Detail(Category.DMA, "Unfrobbed {0:x} -> {1:x}", addr.Value, unfrobbed);
+
+            return unfrobbed;
+        }
+
+        // Debugging
+        public void DumpDMARegisters()
+        {
+            Console.WriteLine("DMA registers:");
+
+            for (var i = ChannelName.uProc; i < ChannelName.Idle; i++)
+            {
+                Console.WriteLine(_channels[(int)i]);
+                Console.WriteLine("Unfrobbed:          {0:x6}        {1:x6}",
+                                  GetHeaderAddress(i), GetDataAddress(i));
+            }
+        }
+
+        internal struct DMAChannel
+        {
+            public DMAChannel(ChannelName chan)
+            {
+                Name = chan;
+
+                // Should be 20 bits for IOB/CIO, 20 or 24 bits for EIO!
+                HeaderAddr = new ExtendedRegister(CPU.CPUBits - 16, 16);
+                DataAddr = new ExtendedRegister(CPU.CPUBits - 16, 16);
+
+                // For EIO, bits <7:4> of the high header address are the complement
+                // of the (quad) word count.  Provided for convenience :-)
+                HeaderCount = 0;
+            }
+
+            public override string ToString()
+            {
+                return string.Format("{0}  Header: {1:x6}  Data: {2:x6}  Count: {3}",
+                                     $"{Name}".PadRight(10), HeaderAddr.Value, DataAddr.Value, HeaderCount);
+            }
+
+            public ChannelName Name;
+            public ExtendedRegister HeaderAddr;
+            public ExtendedRegister DataAddr;
+
+            public byte HeaderCount;
+        }
+
+        DMAChannel[] _channels;
+        Dictionary<byte, LoadRegisterDelegate> _portToChannelAction;
+    }
+}

--- a/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
@@ -43,6 +43,9 @@ namespace PERQemu.IO.DiskDevices
         //  good disassembly of a definitive microcode binary can be found.
         //  The standard MicropolisDiskController is now EIO only.
         //
+        //  Todo: when revisiting this, use the split controller/DIB approach
+        //  that worked so beautifully in the EIO implementation.
+        //
 
         public CIOMicropolisDiskController(PERQSystem system)
         {
@@ -54,7 +57,9 @@ namespace PERQemu.IO.DiskDevices
             _cylinder = new ExtendedRegister(4, 8);
             _nibLatch = new ExtendedRegister(4, 4);
 
-            // 8" drives are only supported on the 20-bit machines...
+            // 8" drives are only supported on the 20-bit machines?
+            // Actually... there is an Accent.PQ2.24.Mboot! but these
+            // are probably deleted with the new DMA registry anyway
             _dataBuffer = new ExtendedRegister(4, 16);
             _headerAddress = new ExtendedRegister(4, 16);
         }
@@ -64,12 +69,9 @@ namespace PERQemu.IO.DiskDevices
         /// </summary>
         public void Reset()
         {
-            if (_disk != null)
-            {
-                _disk.Reset();
-            }
+            _disk?.Reset();
 
-            // Clears busy and the interrupt
+            // Clear busy and the interrupt
             ClearBusyState();
 
             // Force a soft reset (calls ResetFlags)

--- a/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
@@ -227,26 +227,6 @@ namespace PERQemu.IO.DiskDevices
                     Log.Write(Category.HardDisk, "Micropolis Sector # set to 0x{0:x2}", _sector);
                     break;
 
-                case 0xd0:      // Micropolis Data Buffer Address High register
-                    _dataBuffer.Hi = ~value;
-                    Log.Write(Category.HardDisk, "Micropolis Data Buffer Address (high) set to 0x{0:x}", _dataBuffer.Hi);
-                    break;
-
-                case 0xd1:      // Micropolis Header Address High register
-                    _headerAddress.Hi = ~value;
-                    Log.Write(Category.HardDisk, "Micropolis Header Address (high) set to 0x{0:x}", _headerAddress.Hi);
-                    break;
-
-                case 0xd8:      // Micropolis Data Buffer Address Low register
-                    _dataBuffer.Lo = (ushort)value;
-                    Log.Write(Category.HardDisk, "Micropolis Data Buffer Address (low) set to 0x{0:x4}", _dataBuffer.Lo);
-                    break;
-
-                case 0xd9:      // Micropolis Header Address low register
-                    _headerAddress.Lo = (ushort)value;
-                    Log.Write(Category.HardDisk, "Micropolis Header Address (low) set to 0x{0:x4}", _headerAddress.Lo);
-                    break;
-
                 default:
                     throw new InvalidOperationException($"Bad register write 0x{address:x2}");
             }
@@ -273,7 +253,7 @@ namespace PERQemu.IO.DiskDevices
         /// since it's used to turn the Z80 off and on.  So on the CIO, for which we
         /// have no *$)!#*& schematics, does that bit do double duty?
         /// </remarks>
-        public void LoadCommandRegister(int data)
+        void LoadCommandRegister(int data)
         {
             var command = (Command)(data & 0x07);
             var nibCommand = (NibbleSelect)(data & 0x78);

--- a/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/CIOMicropolisDiskController.cs
@@ -29,19 +29,10 @@ namespace PERQemu.IO.DiskDevices
     /// Represents a Micropolis 8" hard drive controller which manages disk
     /// drives in the Disk8Inch class.  This is implemented in the PERQ as an
     /// adapter from the SA4000 interface to the Micropolis 1200-series drives.
+    /// This version of the driver attempts to suss out the CIO version of the
+    /// controller, for which there is almost no documentation or surviving
+    /// software support.
     /// </summary>
-    /// <remarks>
-    /// Although the 1220 controller can manage a string of up to four drives,
-    /// there doesn't appear to be any software support for setting the Drive
-    /// Select value.  This statement in a recently unearthed document also
-    /// corrects my misconception that the ICL cabinet could house two drives:
-    /// 
-    ///     "None of the PERQ cabinets has enough space for mounting more
-    ///      than one 8" drive internally."
-    ///         -- config.doc Rev 3, Steve Clark 18 Dec 84
-    /// 
-    /// As with the Shugart, emulation for now is limited to a single drive. :-(
-    /// </remarks>
     public sealed class CIOMicropolisDiskController : IStorageController
     {
 
@@ -687,6 +678,11 @@ namespace PERQemu.IO.DiskDevices
             {
                 _system.CPU.ClearInterrupt(InterruptSource.HardDisk);
             }
+        }
+
+        public void DumpStatus()
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/PERQemu/Emulator/IO/DiskDevices/FloppyDisk.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/FloppyDisk.cs
@@ -49,9 +49,6 @@ namespace PERQemu.IO.DiskDevices
             _isSingleSided = true;
             _isDoubleDensity = false;
 
-            _cylinder = 1;      // Force a Step Out to find track 0 on startup
-            _head = 0;
-
             _loadDelayEvent = null;
             _seekDelayEvent = null;
         }
@@ -68,7 +65,9 @@ namespace PERQemu.IO.DiskDevices
                 _seekDelayEvent = null;
             }
 
-            // Anything else?
+            _head = 0;          // Reselect head 0 on reset
+            _cylinder = 1;      // Force a Step Out to find track 0 on startup
+
             Log.Debug(Category.FloppyDisk, "Drive reset");
         }
 

--- a/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
@@ -234,7 +234,7 @@ namespace PERQemu.IO.DiskDevices
                 delay = Math.Min(_stepCount * Specs.MinimumSeek, Specs.MaximumSeek);
             }
 
-            Log.Info(Category.HardDisk, "Drive seek to cyl {0} from {1}, {2} steps in {3:n}ms",
+            Log.Debug(Category.HardDisk, "Drive seek to cyl {0} from {1}, {2} steps in {3:n}ms",
                                           cyl, _cyl, _stepCount, delay);
             _cyl = cyl;
 
@@ -263,19 +263,19 @@ namespace PERQemu.IO.DiskDevices
                 {
                     settle = (ulong)Specs.HeadSettling * Conversion.MsecToNsec;
 
-                    Log.Info(Category.HardDisk, "Seek complete [settling callback in {0:n}ms]",
+                    Log.Detail(Category.HardDisk, "Seek complete [settling callback in {0:n}ms]",
                                                   settle * Conversion.NsecToMsec);
                 }
                 else
                 {
-                    Log.Info(Category.HardDisk, "Seek complete [callback in 1us]");
+                    Log.Detail(Category.HardDisk, "Seek complete [callback in 1us]");
                 }
 
                 _scheduler.Schedule(settle, _seekCallback);
             }
             else
             {
-                Log.Info(Category.HardDisk, "Seek complete");
+                Log.Detail(Category.HardDisk, "Seek complete");
             }
         }
 

--- a/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
@@ -336,7 +336,7 @@ namespace PERQemu.IO.DiskDevices
         {
             ulong delay = 100;
 
-            if ((Settings.Performance & RateLimit.StartupDelay) != 0)
+            if (Settings.Performance.HasFlag(RateLimit.StartupDelay) && _lastIndexPulse == 0)
             {
                 // This makes sense if we do the whole "watch the screen warm up
                 // and play audio of the fans & disks whirring" for the total
@@ -347,15 +347,15 @@ namespace PERQemu.IO.DiskDevices
                 // really appreciate this attention to detail.  Otherwise it's
                 // basically just insane.
 
-                // Introduce a little variation, from 50-95% of max startup time
+                // Introduce a little variation, from 66-99% of max startup time
                 var rand = new Random();
-                delay = (ulong)(Specs.StartupDelay / 100 * rand.Next(50, 95));
+                delay = (ulong)(Specs.StartupDelay / 100 * rand.Next(66, 99));
             }
 
             _startupEvent = _scheduler.Schedule(delay * Conversion.MsecToNsec, DriveReady);
 
-            Log.Debug(Category.HardDisk, "Drive {0} motor start ({1} sec delay)",
-                      Info.Name, delay * Conversion.MsecToSec);
+            Log.Debug(Category.HardDisk, "Drive {0} motor start (ready in {1:n} seconds)",
+                                          Info.Name, delay * Conversion.MsecToSec);
         }
 
         /// <summary>

--- a/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
@@ -73,42 +73,31 @@ namespace PERQemu.IO.DiskDevices
         /// <summary>
         /// Does a hardware reset on the device.
         /// </summary>
-        public virtual void Reset(bool soft = false)
+        public virtual void Reset()
         {
             if (!IsLoaded)
             {
-                // Not really relevant until we support removable pack hard drives?
+                // Not really relevant until we support removable pack hard drives
                 Log.Warn(Category.HardDisk, "Reset called but no disk loaded!");
                 _fault = true;
                 return;
             }
 
-            // A "soft" reset from the controller just clears the fault status
-            // and should probably clear the seek state... but what if a seek
-            // is in progress?  Abort or wait for motion to stop?
-
+            // Clear fault status and reset the seek state
             FaultClear();
             StopSeek();
 
-            if (soft) return;
+            // Schedule a motor start to bring the drive up to speed (if it isn't
+            // already); will bring the drive on-line and set the ready bit
+            MotorStart();
 
-            // A "hard" reset is from a power-on or reboot
-            _ready = false;
-            _index = false;
-            _seekComplete = false;
-
-            if (_startupEvent == null)
-            {
-                // Cold start: schedule a ready event so our drive can
-                // come up to speed.  Todo: play the spin-up audio! :-)
-                MotorStart();
-            }
-
+            // Stop the current index event and reset, restart it
             if (_indexEvent != null)
             {
                 _scheduler.Cancel(_indexEvent);
             }
 
+            _index = false;
             IndexPulseStart(0, null);
         }
 
@@ -228,41 +217,29 @@ namespace PERQemu.IO.DiskDevices
         /// For 8" or 5.25" drives with embedded controllers, computes the timing
         /// for a seek from the current head position to the requested cylinder.
         /// Assumes the controller checks bounds and that it tracks busy status,
-        /// not initiating a new seek while one in progress...
+        /// not initiating a new seek while one is in progress...
         /// </remarks>
         public virtual void SeekTo(ushort cyl)
         {
-            // Quick and dirty time delay, probably not very accurate; clamp it
-            // to the max seek according to the specs (though if rate limiting
-            // is off, we could clip that to a "reasonable" minimum).
+            // NB: If the heads are already over the requested cylinder, we DO
+            // fire the completion callback, with a minimal (1 usec) delay so
+            // that the microcode can potentially catch the state machine's idle
+            // to busy transition (which some versions explicitly check for).
 
-            // NB: If the heads are already over the requested cylinder, we don't
-            // fire the SeekCompletion callback!  It _seems_ that the microcode
-            // generally checks for this and doesn't issue the seek in the first
-            // place, but we shouldn't rely on that; the question is whether the
-            // completion interrupt will cause more problems (at boot time) than
-            // treating a zero-track seek as a no-op solves.  This will have to
-            // be revisited when EIO is implemented (or if CIO Micropolis is ever
-            // figured out).  A 1usec delay for head switching isn't unreasonable
-            // if no head movement takes place?
-
-            var steps = Math.Abs(_cyl - cyl);
             var delay = Specs.MinimumSeek;
+            _stepCount = Math.Abs(_cyl - cyl);
 
-            if (Settings.Performance.HasFlag(RateLimit.DiskSpeed) && steps > 0)
+            if (Settings.Performance.HasFlag(RateLimit.DiskSpeed) && _stepCount > 0)
             {
-                delay = Math.Min(steps * Specs.MinimumSeek, Specs.MaximumSeek);
+                delay = Math.Min(_stepCount * Specs.MinimumSeek, Specs.MaximumSeek);
             }
 
-            Log.Debug(Category.HardDisk, "Seek to cyl {0} from {1}, {2} steps in {3:n}ms",
-                                          cyl, _cyl, steps, delay);
+            Log.Info(Category.HardDisk, "Drive seek to cyl {0} from {1}, {2} steps in {3:n}ms",
+                                          cyl, _cyl, _stepCount, delay);
             _cyl = cyl;
 
-            if (delay > 0)
-            {
-                // Schedule the callback
-                _seekEvent = _scheduler.Schedule((ulong)delay * Conversion.MsecToNsec, SeekCompletion);
-            }
+            // Schedule the callback
+            _seekEvent = _scheduler.Schedule((ulong)delay * Conversion.MsecToNsec, SeekCompletion);
         }
 
         /// <summary>
@@ -282,19 +259,23 @@ namespace PERQemu.IO.DiskDevices
                 // If faithfully emulating the slow ass disk drives of the mid-
                 // 1980s, then add the head settling time to cap off our seek
                 // odyssey.  Otherwise a default 1us delay is reasonable.
-                if ((Settings.Performance & RateLimit.DiskSpeed) != 0 && Specs.HeadSettling > 0)
+                if (Settings.Performance.HasFlag(RateLimit.DiskSpeed) && _stepCount > 0 && Specs.HeadSettling > 0)
                 {
                     settle = (ulong)Specs.HeadSettling * Conversion.MsecToNsec;
-                }
 
-                Log.Debug(Category.HardDisk, "Seek complete [settling callback in {0:n}ms]",
-                                              settle * Conversion.NsecToMsec);
+                    Log.Info(Category.HardDisk, "Seek complete [settling callback in {0:n}ms]",
+                                                  settle * Conversion.NsecToMsec);
+                }
+                else
+                {
+                    Log.Info(Category.HardDisk, "Seek complete [callback in 1us]");
+                }
 
                 _scheduler.Schedule(settle, _seekCallback);
             }
             else
             {
-                Log.Debug(Category.HardDisk, "Seek complete");
+                Log.Info(Category.HardDisk, "Seek complete");
             }
         }
 
@@ -329,33 +310,42 @@ namespace PERQemu.IO.DiskDevices
         }
 
         /// <summary>
-        /// Spin up the virtual drive.  This schedules an event to raise the
-        /// ready signal (which should cause an interrupt) after hardware reset.
+        /// Spin up the virtual drive on a cold start.  This schedules an event to
+        /// raise the ready signal (which should cause an interrupt) after hardware
+        /// reset.  If already on-line, calls DriveReady without delay.
         /// </summary>
         void MotorStart()
         {
-            ulong delay = 100;
-
-            if (Settings.Performance.HasFlag(RateLimit.StartupDelay) && _lastIndexPulse == 0)
+            if (!_ready && _startupEvent == null)
             {
-                // This makes sense if we do the whole "watch the screen warm up
-                // and play audio of the fans & disks whirring" for the total
-                // multimedia experience.  If we just rewrote this as a fully
-                // immersive 60fps 3D game, texture mapping the screen output
-                // to the display and simulating actual keyboard presses through
-                // data glove/VR or 3D first person shooter style, then you'd
-                // really appreciate this attention to detail.  Otherwise it's
-                // basically just insane.
+                ulong delay = 100;
 
-                // Introduce a little variation, from 66-99% of max startup time
-                var rand = new Random();
-                delay = (ulong)(Specs.StartupDelay / 100 * rand.Next(66, 99));
+                if (Settings.Performance.HasFlag(RateLimit.StartupDelay) && _lastIndexPulse == 0)
+                {
+                    // This makes sense if we do the whole "watch the screen warm up
+                    // and play audio of the fans & disks whirring" for the total
+                    // multimedia experience.  If we just rewrote this as a fully
+                    // immersive 60fps 3D game, texture mapping the screen output
+                    // to the display and simulating actual keyboard presses through
+                    // data glove/VR or 3D first person shooter style, then you'd
+                    // really appreciate this attention to detail.  Otherwise it's
+                    // basically just insane.
+
+                    // Introduce a little variation, from 66-99% of max startup time
+                    var rand = new Random();
+                    delay = (ulong)(Specs.StartupDelay / 100 * rand.Next(66, 99));
+                }
+
+                _startupEvent = _scheduler.Schedule(delay * Conversion.MsecToNsec, DriveReady);
+
+                Log.Info(Category.HardDisk, "Drive {0} motor start (ready in {1:n} seconds)",
+                                              Info.Name, delay * Conversion.MsecToSec);
             }
-
-            _startupEvent = _scheduler.Schedule(delay * Conversion.MsecToNsec, DriveReady);
-
-            Log.Debug(Category.HardDisk, "Drive {0} motor start (ready in {1:n} seconds)",
-                                          Info.Name, delay * Conversion.MsecToSec);
+            else
+            {
+                // On a reset, just assume the drive is online
+                DriveReady(0, null);
+            }
         }
 
         /// <summary>

--- a/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/HardDisk.cs
@@ -247,9 +247,9 @@ namespace PERQemu.IO.DiskDevices
             // if no head movement takes place?
 
             var steps = Math.Abs(_cyl - cyl);
-            var delay = (Specs.MinimumSeek);
+            var delay = Specs.MinimumSeek;
 
-            if (Settings.Performance.HasFlag(RateLimit.DiskSpeed))
+            if (Settings.Performance.HasFlag(RateLimit.DiskSpeed) && steps > 0)
             {
                 delay = Math.Min(steps * Specs.MinimumSeek, Specs.MaximumSeek);
             }

--- a/PERQemu/Emulator/IO/DiskDevices/MFMDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/MFMDiskController.cs
@@ -1,0 +1,89 @@
+﻿//
+// MFMDiskController.cs - Copyright (c) 2006-2024 Josh Dersch (derschjo@gmail.com)
+//
+// This file is part of PERQemu.
+//
+// PERQemu is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// PERQemu is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PERQemu.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using PERQmedia;
+
+namespace PERQemu.IO.DiskDevices
+{
+    /// <summary>
+    /// Represents the 5.25" hard drive controller on the EIO board which manages
+    /// disk drives in the Disk5Inch class.  This is implemented in the PERQ as an
+    /// adapter from the SA4000 interface to a variety of MFM/ST-506 style drives.
+    /// This version emulates both types of DIB (one which supports write pre-
+    /// compensation, and the other that doesn't).  See Docs/HardDisk.txt for more.
+    /// </summary>
+    public sealed class MFMDiskController : IStorageController
+    {
+        public MFMDiskController()
+        {
+            _dib = new DiskInterfaceBoard(this);
+        }
+
+        public void Reset()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AttachDrive(uint unit, StorageDevice dev)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LoadRegister(byte address, int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DoSingleSeek()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int ReadStatus()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DumpStatus()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// The 5.25" Disk Interface Board.  Uses a six-bit bus, similar to but
+        /// very distinct from the 8" DIB used in the Micropolis driver.
+        /// </summary>
+        /// <remarks>
+        /// In theory the EIO board could be jumpered to talk to all three types
+        /// of drives, but that's way too messy and confusing. 
+        /// </remarks>
+        internal class DiskInterfaceBoard
+        {
+            public DiskInterfaceBoard(MFMDiskController control)
+            {
+                _drives = new HardDisk[2];  // Four, someday? :-)
+            }
+
+            HardDisk[] _drives;
+        }
+
+        DiskInterfaceBoard _dib;
+    }
+}

--- a/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
@@ -498,6 +498,8 @@ namespace PERQemu.IO.DiskDevices
             {
                 Log.Write(Category.HardDisk, "FinishCommand completion: {0}", code);
                 _status = code;
+                _busyEvent = null;
+
                 SetInterrupt(true);
             });
         }

--- a/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
@@ -53,10 +53,6 @@ namespace PERQemu.IO.DiskDevices
             // ExtendedRegisters to glom the register writes together!
             _cylinder = new ExtendedRegister(4, 8);
             _nibLatch = new ExtendedRegister(4, 4);
-
-            // 8" drives are only supported on the 20-bit machines, for now
-            _dataBuffer = new ExtendedRegister(4, 16);
-            _headerAddress = new ExtendedRegister(4, 16);
         }
 
         /// <summary>
@@ -93,8 +89,6 @@ namespace PERQemu.IO.DiskDevices
 
             _nibSaved = 0;
             _nibLatch.Value = 0;
-            _headerAddress.Value = 0;
-            _dataBuffer.Value = 0;
         }
 
         /// <summary>
@@ -129,15 +123,13 @@ namespace PERQemu.IO.DiskDevices
         /// </summary>
         public void LoadRegister(byte address, int value)
         {
-            // FIXME:  redo all of this for the EIO!
-
             switch (address)
             {
-                case 0xc1:      // Command register
-                    LoadCommandRegister(value);
-                    break;
+                //case 0xc1:      // Command register
+                //    LoadCommandRegister(value);
+                //    break;
 
-                case 0xc2:      // Micropolis Nibble Bus register
+                //case 0xc2:      // Micropolis Nibble Bus register
                     //
                     // We save the low 4 bits here.  The nibble command byte tracks
                     // transitions of the BusEn pin to shift the low nibble into the
@@ -146,11 +138,11 @@ namespace PERQemu.IO.DiskDevices
                     // In others this is still treated like the Shugart head select!?
                     // ARGH.
                     //
-                    _nibLatch.Lo = (ushort)value;
-                    Log.Write(Category.HardDisk, "Micropolis Nibble latch (low) set to 0x{0:x}", _nibLatch.Lo);
-                    break;
+                //    _nibLatch.Lo = (ushort)value;
+                //    Log.Write(Category.HardDisk, "Micropolis Nibble latch (low) set to 0x{0:x}", _nibLatch.Lo);
+                //    break;
 
-                case 0xc8:      // "MicZero"
+                //case 0xc8:      // "MicZero"
                     //
                     // Unused by the actual "ICL CIO" board?  Original version of
                     // the Micropolis microcode (mdsk.micro, B. Rosen, 1982) uses
@@ -158,15 +150,15 @@ namespace PERQemu.IO.DiskDevices
                     // register.  On that board cioboot and ciosysb assign a 0 and
                     // don't touch this again.  Hmm.
                     //
-                    _sector = (ushort)(value & 0x1f);
-                    _head = (byte)((value & 0xe0) >> 5);
-                    _cylinder.Lo = (ushort)((value & 0xff00) >> 8);
+                    //_sector = (ushort)(value & 0x1f);
+                    //_head = (byte)((value & 0xe0) >> 5);
+                    //_cylinder.Lo = (ushort)((value & 0xff00) >> 8);
 
-                    Log.Write(Category.HardDisk, "Shugart cyl/head/sector set to {0}/{1}/{2}", _cylinder.Lo, _head, _sector);
-                    Log.Write(Category.HardDisk, "Micropolis Zero register set to 0x{0:x}", value);
-                    break;
+                    //Log.Write(Category.HardDisk, "Shugart cyl/head/sector set to {0}/{1}/{2}", _cylinder.Lo, _head, _sector);
+                    //Log.Write(Category.HardDisk, "Micropolis Zero register set to 0x{0:x}", value);
+                //    break;
 
-                case 0xc9:      // "MicSync"
+                //case 0xc9:      // "MicSync"
                     //
                     // Does this set up the sync character used by the hardware to
                     // identify address marks (?) - low level format byte (?) is
@@ -174,25 +166,25 @@ namespace PERQemu.IO.DiskDevices
                     // cases it's still used as the File SN (which we don't actually
                     // use to compare with the header bytes...)
                     //
-                    Log.Write(Category.HardDisk, "Micropolis Sync register set to 0x{0:x}", value);
+                    //Log.Write(Category.HardDisk, "Micropolis Sync register set to 0x{0:x}", value);
 
                     //_serialNumber.Lo = (ushort)value;
                     //Log.Write(Category.HardDisk, "Shugart File Serial # Low set to 0x{0:x4}", value);
-                    break;
+                //    break;
 
-                case 0xca:      // "MicCylin"
+                //case 0xca:      // "MicCylin"
                     //
                     // Low byte of the desired cylinder inverted!?  Or high word
                     // of the File SN?  Yes.  No.  Who knows?
                     //
-                    _cylinder.Lo = (ushort)~value;
-                    Log.Write(Category.HardDisk, "Micropolis Cyl # (low) set to 0x{0:x2}", _cylinder.Lo);
+                    //_cylinder.Lo = (ushort)~value;
+                    //Log.Write(Category.HardDisk, "Micropolis Cyl # (low) set to 0x{0:x2}", _cylinder.Lo);
 
                     //_serialNumber.Hi = value;
                     //Log.Write(Category.HardDisk, "Shugart File Serial # High set to 0x{0:x}", value);
-                    break;
+                //    break;
 
-                case 0xcb:      // "MicCylHd"
+                //case 0xcb:      // "MicCylHd"
                     //
                     // Bits 7:4 are cylinder 11:8
                     // Bits 3:0 are the head select (inverted!?)
@@ -200,44 +192,32 @@ namespace PERQemu.IO.DiskDevices
                     // Wheeee!  No documentation or schematics!  Looks like manual
                     // disassembly and step by step instruction traces ahead  arrrgh
                     //
-                    _cylinder.Hi = (~value & 0xf0) >> 4;
-                    _head = (byte)(~value & 0x0f);
-                    Log.Write(Category.HardDisk, "Micropolis Cyl # (high) set to 0x{0:x}, Head 0x{1:x}", _cylinder.Hi, _head);
+                    //_cylinder.Hi = (~value & 0xf0) >> 4;
+                    //_head = (byte)(~value & 0x0f);
+                    //Log.Write(Category.HardDisk, "Micropolis Cyl # (high) set to 0x{0:x}, Head 0x{1:x}", _cylinder.Hi, _head);
 
                     //_blockNumber = value & 0xffff;
                     //Log.Write(Category.HardDisk, "Shugart Block # set to 0x{0:x}", value);
-                    break;
+                //    break;
 
-                case 0xcc:      // "MicSecNo"
+                //case 0xcc:      // "MicSecNo"
                     //
                     // Sector number (8 bits, though only 5 are significant?)
                     // And yet, haven't seen a version of the code that actually
                     // sets this even though it (sometimes) is loaded into the
                     // controlstore.  Sigh.
                     //
-                    _sector = (ushort)(value & 0xff);
+                    //_sector = (ushort)(value & 0xff);
 
-                    Log.Write(Category.HardDisk, "Micropolis Sector # set to 0x{0:x2}", _sector);
-                    break;
+                    //Log.Write(Category.HardDisk, "Micropolis Sector # set to 0x{0:x2}", _sector);
+                    //break;
 
-                case 0xd0:      // Micropolis Data Buffer Address High register
-                    _dataBuffer.Hi = ~value;
-                    Log.Write(Category.HardDisk, "Micropolis Data Buffer Address (high) set to 0x{0:x}", _dataBuffer.Hi);
-                    break;
-
-                case 0xd1:      // Micropolis Header Address High register
-                    _headerAddress.Hi = ~value;
-                    Log.Write(Category.HardDisk, "Micropolis Header Address (high) set to 0x{0:x}", _headerAddress.Hi);
-                    break;
-
-                case 0xd8:      // Micropolis Data Buffer Address Low register
-                    _dataBuffer.Lo = (ushort)value;
-                    Log.Write(Category.HardDisk, "Micropolis Data Buffer Address (low) set to 0x{0:x4}", _dataBuffer.Lo);
-                    break;
-
-                case 0xd9:      // Micropolis Header Address low register
-                    _headerAddress.Lo = (ushort)value;
-                    Log.Write(Category.HardDisk, "Micropolis Header Address (low) set to 0x{0:x4}", _headerAddress.Lo);
+                case 0xd0:
+                case 0xd1:
+                case 0xd2:
+                case 0xd3:
+                    //LoadCommandRegister(value);
+                    Log.Warn(Category.HardDisk, "Micropolis: Write of 0x{0:x4} to register 0x{1:x2} (unimplemented)", value, address);
                     break;
 
                 default:
@@ -266,7 +246,7 @@ namespace PERQemu.IO.DiskDevices
         /// since it's used to turn the Z80 off and on.  So on the CIO, for which we
         /// have no *$)!#*& schematics, does that bit do double duty?
         /// </remarks>
-        public void LoadCommandRegister(int data)
+        void LoadCommandRegister(int data)
         {
             var command = (Command)(data & 0x07);
             var nibCommand = (NibbleSelect)(data & 0x78);
@@ -785,10 +765,6 @@ namespace PERQemu.IO.DiskDevices
         byte _head;
         ushort _sector;
         ExtendedRegister _cylinder;
-
-        ExtendedRegister _headerAddress;
-        ExtendedRegister _dataBuffer;
-
         ExtendedRegister _nibLatch;
         NibbleSelect _nibCommand;
         byte _nibSaved;

--- a/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/MicropolisDiskController.cs
@@ -165,7 +165,7 @@ namespace PERQemu.IO.DiskDevices
                     break;
 
                 default:
-                    throw new InvalidOperationException($"Bad register write 0x{address:x2}");
+                    throw new UnhandledIORequestException(address, value);
             }
         }
 

--- a/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
@@ -34,7 +34,6 @@ namespace PERQemu.IO.DiskDevices
         {
             _system = system;
             _disk = null;
-            _busyEvent = null;
 
             // This is assembled from separate register writes, so let
             // ExtendedRegister do the work to combine 'em!
@@ -46,10 +45,7 @@ namespace PERQemu.IO.DiskDevices
         /// </summary>
         public void Reset()
         {
-            if (_disk != null)
-            {
-                _disk.Reset();
-            }
+            _disk?.Reset();
 
             _cylinder = 0;
             _head = 0;
@@ -496,7 +492,7 @@ namespace PERQemu.IO.DiskDevices
             // if we're NOT doing a seek -- because reasons okay
             if (_command != Command.Seek)
             {
-                _busyEvent = _system.Scheduler.Schedule(delay, (skew, context) =>
+                _system.Scheduler.Schedule(delay, (skew, context) =>
                 {
                     ClearBusyState(true);
                 });
@@ -624,8 +620,6 @@ namespace PERQemu.IO.DiskDevices
         // fiddle with this to make it more realistic.
         readonly ulong BlockDelayNsec = 585 * Conversion.UsecToNsec;
 
-        SchedulerEvent _busyEvent;
-
-        PERQSystem _system;
+        readonly PERQSystem _system;
     }
 }

--- a/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
@@ -170,7 +170,7 @@ namespace PERQemu.IO.DiskDevices
         ///         5     fault clear         /
         ///       6:7     unit select!?      /    Z80 control bit (conflict!)
         /// </remarks>
-        public void LoadCommandRegister(int data)
+        void LoadCommandRegister(int data)
         {
             _command = (Command)(data & 0x07);
             _seekCommand = (SeekCommand)(data & 0x78);

--- a/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
+++ b/PERQemu/Emulator/IO/DiskDevices/ShugartDiskController.cs
@@ -521,6 +521,19 @@ namespace PERQemu.IO.DiskDevices
             }
         }
 
+        /// <summary>
+        /// Dump internal state to the console.
+        /// </summary>
+        public void DumpStatus()
+        {
+            var stat = DiskStatus;
+
+            Console.WriteLine("Shugart hard drive status:");
+            Console.WriteLine($"  Command: {_command}  Busy: {_controllerBusy}");
+            Console.WriteLine($"  Seek command:  {_seekCommand}  State: {_seekState}");
+            Console.WriteLine($"  Disk status:   0x{stat:x4} ({(Status)stat})");
+        }
+
         enum SeekState
         {
             WaitForStepSet = 0,

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -38,6 +38,7 @@ namespace PERQemu.IO
         {
             _name = "EIO";
             _desc = "PERQ-2 I/O Board, Z80A, Microp/MFM, Ethernet";
+            _isEIO = true;
 
             _z80CycleTime = 250;    // 4Mhz!
 

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -128,6 +128,9 @@ namespace PERQemu.IO
         {
             switch (port)
             {
+                case 0x52:      // E10ERdNetSR: read Ethernet status
+                    return _ethernetController?.ReadStatus() ?? 0xff;
+
                 case 0x53:      // SMStat: read disk status reg
                     return _hardDiskController.ReadStatus();
 
@@ -136,6 +139,10 @@ namespace PERQemu.IO
 
                 case 0x55:      // EioZ80Stat: read Z80 interface status
                     return _z80System.ReadStatus();
+
+                case 0x5a:
+                case 0x5b:
+                    return _ethernetController?.ReadRegister(port) ?? 0xff;
 
                 default:
                     Log.Warn(Category.IO, "Unhandled EIO Read from port {0:x2}", port);
@@ -186,6 +193,9 @@ namespace PERQemu.IO
 
                 // Load Ethernet registers
                 case 0xc2:
+                     _ethernetController?.LoadCommand(value);
+                    break;
+
                 case 0xc3:
                 case 0xc8:
                 case 0xc9:
@@ -201,10 +211,7 @@ namespace PERQemu.IO
                 case 0xdc:
                 case 0xdd:
                 case 0xde:
-                    if (_ethernetController != null)
-                    {
-                        _ethernetController.LoadRegister(port, value);
-                    }
+                    _ethernetController?.LoadRegister(port, value);
                     break;
 
                 default:

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -160,8 +160,7 @@ namespace PERQemu.IO
                     return _ethernetController?.ReadRegister(port) ?? 0xff;
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled EIO Read from port {0:x2}", port);
-                    return 0xff;
+                    throw new UnhandledIORequestException(port);
             }
         }
 
@@ -226,8 +225,7 @@ namespace PERQemu.IO
                     break;
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled EIO Write to port {0:x2}, data {1:x4}", port, value);
-                    break;
+                    throw new UnhandledIORequestException(port, value);
             }
         }
 

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -85,8 +85,7 @@ namespace PERQemu.IO
                      system.Config.GetDrivesOfType(DeviceType.Disk5Inch).Length > 0)
             {
                 // A PERQ-2/T2 or 2/T4
-                // _hardDiskController = new MFMDiskController(system);
-                throw new UnimplementedHardwareException("MFMDiskController not yet implemented");
+                _hardDiskController = new MFMDiskController();
             }
             else
             {
@@ -128,7 +127,7 @@ namespace PERQemu.IO
         {
             switch (port)
             {
-                case 0x53:      // DskStat (SMStat): read disk status reg
+                case 0x53:      // SMStat: read disk status reg
                     return _hardDiskController.ReadStatus();
 
                 case 0x54:      // 124 EioZ80In: dismiss Z80 interrupt
@@ -157,7 +156,10 @@ namespace PERQemu.IO
 
                 // Z80 control register
                 case 0xc5:
-                    // Todo: if bit 3 set, inform the PDMA
+                    // Note: if bit 3 set, DMA address generation is disabled for
+                    // the ExtA channel.  So far none of the known optional I/O
+                    // devices use that functionality.  Audre?  MLO?  It seems very
+                    // unlikely that emulation of this feature will ever be needed.
                     _z80System.WriteStatus(value);
                     break;
 

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -30,7 +30,7 @@ namespace PERQemu.IO
     /// <summary>
     /// Represents an EIO or NIO card in a PERQ2 system.  This contains hardware
     /// for a Micropolis or MFM disk controller, an Ethernet controller (not
-    /// present on the NIO) and a Z80 for controlling low-speed devices.
+    /// present on the NIO) and a Z80 subsystem for attaching low-speed devices.
     /// </summary>
     public sealed class EIO : IOBoard
     {
@@ -85,7 +85,7 @@ namespace PERQemu.IO
                      system.Config.GetDrivesOfType(DeviceType.Disk5Inch).Length > 0)
             {
                 // A PERQ-2/T2 or 2/T4
-                _hardDiskController = new MFMDiskController();
+                _hardDiskController = new MFMDiskController(/* incomplete */);
             }
             else
             {
@@ -130,10 +130,10 @@ namespace PERQemu.IO
                 case 0x53:      // SMStat: read disk status reg
                     return _hardDiskController.ReadStatus();
 
-                case 0x54:      // 124 EioZ80In: dismiss Z80 interrupt
+                case 0x54:      // EioZ80In: dismiss Z80 interrupt
                     return _z80System.ReadData();
 
-                case 0x55:      // 125 EioZ80Stat: read Z80 interface status
+                case 0x55:      // EioZ80Stat: read Z80 interface status
                     return _z80System.ReadStatus();
 
                 default:
@@ -280,7 +280,7 @@ namespace PERQemu.IO
 
         /// <remarks>
         /// These EIO registers are not implemented:
-        /// 120     50      FPSat           read floating point status
+        /// 120     50      FPStat          read floating point status
         /// 121     51      FPResult        read floating point result
         /// 234     9C      AdrReg*         enable state machine addr reg
         /// 235     9D      WrtRam*         load ethernet test mumble
@@ -296,51 +296,3 @@ namespace PERQemu.IO
         ChannelName _chanSelect;
     }
 }
-
-/*
-    Notes:
-
-    This write register needs some special attention:
-    
-           305  Control register  bit 3  - Disable Ext A address
-                                           (see PERQ DMA)
-                                  bit 2  - Z80 reset when clear
-                                  bit 1  - Enable write channel;
-                                           interrupt when set
-                                  bit 0  - Enable read channel;
-                                           interrupt when set
-
-    ACK!  This is very confusing and finicky:
-
-    PERQ TO the Z80 is the "Write FIFO", or Z80 IO BUS INPUT (schematics pg 10):
-    
-        writes data to port 304 (LD_UPROC_DATA_L) trigger PERQ_INT on the Z80
-        and set UPROC_RDY if the FIFO OR signal is true (i.e., not empty)
-
-        control register (port 305) bit 1 is the UPROC_RDY_ENB flag; this enables
-        the UPROC_RDY_INT_L interrupt (Z80DataOut) to be sent TO the PERQ when
-        there is NO data in the FIFO AND the UPROC_RDY_ENB is set (meaning, "I'm
-        ready for more data")
-
-        bit 0 is the UPROC_ENB flag, which enables read-side (Z80DataIn) interrupts
-        (see below)
-
-        data is read from the FIFO on port 124 (0x54) RD_UPROC_DATA_L
-
-        the PERQ UPROC_INT_L is asserted when IOD_OUT_RDY is asserted by the Z80,
-        the FIFO OR is asserted (i.e., not empty) and the UPROC_ENB bit is set.
-
-        reads from the status register (125, 0x55, RD_UPROC_STAT_L) return the
-        IOD_OUT_RDY (output ready) bit as set by the Z80 directly) and UPROC_RDY
-        (meaning the Z80->PERQ FIFO is empty)
-        
-
-    Z80 to the PERQ is the "Read FIFO", mislabeled Z80 IO BUS INPUT (schematics
-    pg 9) when it is clearly output from BUF_D<> -> IOB<>
-
-        IOD_OUT_RDY is the one-bit register written to by the Z80 when it has
-        data to send TO the PERQ; it is latched in the '259 by writes to the
-        control register at port 170Q (0x78)
-
-        data bytes are queued by writes to port 161Q (0x71), SEL_IOD_WR_L
-*/

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -37,7 +37,7 @@ namespace PERQemu.IO
         static EIO()
         {
             _name = "EIO";
-            _desc = "PERQ-2 I/O Board, new Z80, Microp/MFM, Ethernet";
+            _desc = "PERQ-2 I/O Board, Z80A, Microp/MFM, Ethernet";
 
             _z80CycleTime = 250;    // 4Mhz!
 

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -58,8 +58,8 @@ namespace PERQemu.IO
             // the actual ROM dump, so the ROM loader wants to match the RomSize
             // to the length of the actual file.
             //
-            _z80RamSize = 0x1800;   // 6K (of 16K) RAM
-            _z80RamAddr = 0x6800;
+            _z80RamSize = 0x4000;   // 16K RAM
+            _z80RamAddr = 0x4000;
             _z80RomSize = 0x1000;   // 4K (of 8K) ROM
             _z80RomAddr = 0x0;
         }

--- a/PERQemu/Emulator/IO/EIO.cs
+++ b/PERQemu/Emulator/IO/EIO.cs
@@ -124,6 +124,13 @@ namespace PERQemu.IO
 
         public INetworkController Ether => _ethernetController;
 
+        public override void Reset()
+        {
+            _ethernetController?.Reset();
+
+            base.Reset();
+        }
+
         /// <summary>
         /// Reads a word from the given I/O port.
         /// </summary>

--- a/PERQemu/Emulator/IO/IOB.cs
+++ b/PERQemu/Emulator/IO/IOB.cs
@@ -73,8 +73,7 @@ namespace PERQemu.IO
                     return _z80System.ReadData();
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled IOB Read from port {0:x2}", port);
-                    return 0xffff;
+                    throw new UnhandledIORequestException(port);
             }
         }
 
@@ -131,8 +130,7 @@ namespace PERQemu.IO
                     break;
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled IOB Write to port {0:x2}, data {1:x4}", port, value);
-                    break;
+                    throw new UnhandledIORequestException(port, value);
             }
         }
 

--- a/PERQemu/Emulator/IO/IOB.cs
+++ b/PERQemu/Emulator/IO/IOB.cs
@@ -102,28 +102,28 @@ namespace PERQemu.IO
                     _hardDiskController.LoadRegister(port, value);
                     break;
 
-                case 0xd0:      // DMA Registers
+                case 0xd0:      // DMA Registers: Hard disk (Shugart/Microp)
                 case 0xd1:
                 case 0xd8:
                 case 0xd9:
                     _dmaRegisters.LoadRegister(ChannelName.HardDisk, port, value);
                     break;
 
-                case 0xd2:
+                case 0xd2:      // DMA: Network (unused)
                 case 0xd3:
                 case 0xda:
                 case 0xdb:
                     _dmaRegisters.LoadRegister(ChannelName.Network, port, value);
                     break;
 
-                case 0xd4:
+                case 0xd4:      // DMA: Ext B (OIO Canon)
                 case 0xd5:
                 case 0xdc:
                 case 0xdd:
                     _dmaRegisters.LoadRegister(ChannelName.ExtB, port, value);
                     break;
 
-                case 0xd6:
+                case 0xd6:      // DMA: Ext A (OIO Ethernet or Ether3Mbit)
                 case 0xd7:
                 case 0xde:
                 case 0xdf:

--- a/PERQemu/Emulator/IO/IStorageController.cs
+++ b/PERQemu/Emulator/IO/IStorageController.cs
@@ -47,10 +47,15 @@ namespace PERQemu.IO
         /// Initiate a seek operation.
         /// </summary>
         /// <remarks>
-        /// Useful for the Z80-controlled IOB/CIO seek hardware; not sure yet
-        /// how the EIO manages that, but assume it's built-in to the 2910-
-        /// based disk state machine firmware?
+        /// Useful for the Z80-controlled IOB/CIO seek hardware; for EIO drives,
+        /// the DIB hardware incorporates the step pulse generation.
         /// </remarks>
         void DoSingleSeek();
+
+        /// <summary>
+        /// Debugging access.  For now a CLI hook to provide some visibility into the
+        /// driver's internal state (dump to the console).  Not terribly sophisticated.
+        /// </summary>
+        void DumpStatus();
     }
 }

--- a/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
+++ b/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
@@ -237,11 +237,11 @@ namespace PERQemu.IO.Network
                     break;
 
                 case 0xc3:
-                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to net interrupt enable reg", value);
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to net interrupt enable reg", value);
                     break;
 
                 default:
-                    throw new InvalidOperationException($"Unhandled write to port 0x{address:x}");
+                    throw new UnhandledIORequestException(address, value);
             }
         }
 
@@ -332,7 +332,7 @@ namespace PERQemu.IO.Network
                     return retVal;
 
                 default:
-                    throw new InvalidOperationException($"Unhandled read from port 0x{address:x}");
+                    throw new UnhandledIORequestException(address);
             }
         }
 
@@ -368,7 +368,7 @@ namespace PERQemu.IO.Network
             // regardless of whether the net or timer raised it -- or both!?
             _system.CPU.ClearInterrupt(_irq);
             Log.Info(Category.Ethernet, "Read status: {0} interrupt cleared, flags {1} ({2:x})",
-                                        _irq, _status, retVal);
+                                         _irq, _status, retVal);
             return retVal;
         }
 
@@ -383,7 +383,7 @@ namespace PERQemu.IO.Network
             var addr = _system.IOB.DMARegisters.GetHeaderAddress(_dmaRx);
             var words = _physAddr.Unscrambled(_system.IOB.IsEIO);
 
-            Log.Debug(Category.Ethernet, "Writing machine address to 0x{0:x6}", addr);
+            Log.Info(Category.Ethernet, "Writing machine address to 0x{0:x6}", addr);
 
             // DMA the unscrambled address bytes into the header buffer
             for (var i = 0; i < words.Length; i++)

--- a/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
+++ b/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
@@ -189,22 +189,26 @@ namespace PERQemu.IO.Network
                     break;
 
                 //
-                // Receive address
+                // Receive Address setup
                 //
-                case 0x90:      // OIO Low word of MAC address
-                    // Have to byte swap this, because reasons
-                    _recvAddr.Low = (ushort)(value << 8 | (value & 0xff00) >> 8);
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x4} to low address register 0x{1:x2}", value, address);
+                // Note: the microcode writes these byte swapped but expects them
+                // back in the correct order!  The OIO provides a swapped word,
+                // while the EIO programs each byte individually (inverted).  Sigh.
+                //
+                case 0x90:  // OIO Low word of MAC address - swap the bytes
+                    _recvAddr.LowFifth = (byte)(value & 0xff);
+                    _recvAddr.LowSixth = (byte)(value >> 8);
+                    Log.Info(Category.Ethernet, "Wrote 0x{0:x4} to low address register 0x{1:x2}", value, address);
                     break;
 
-                case 0xc9:      // EIO Low word of MAC address (5th octet)
-                    _recvAddr.Low = (ushort)((value << 8) | (_recvAddr.Low & 0xff));
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 5)", value);
+                case 0xc9:  // EIO Low word (byte 5) of MAC address - swap with 6th
+                    _recvAddr.LowSixth = (byte)(~value & 0xff);
+                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to MAC address byte 5", value);
                     break;
 
-                case 0xc8:      // EIO Low word of MAC address (6th octet)
-                    _recvAddr.Low = (ushort)((_recvAddr.Low & 0xff00) | (value & 0xff));
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 6)", value);
+                case 0xc8:  // EIO Low word (byte 6) of MAC address - swap with 5th
+                    _recvAddr.LowFifth = (byte)(~value & 0xff);
+                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to MAC address byte 6", value);
                     break;
 
                 //
@@ -228,7 +232,7 @@ namespace PERQemu.IO.Network
                 case 0xce:      // EIO Multicast group 4
                 case 0xcf:      // EIO Multicast group 5
                     var mcgb = address - 0xca;
-                    _mcastGroups[mcgb] = (byte)(value & 0xff);
+                    _mcastGroups[mcgb] = (byte)(~value & 0xff);
                     Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to multicast register {1} (0x{2:x2})", value, mcgb, address);
                     break;
 
@@ -368,21 +372,24 @@ namespace PERQemu.IO.Network
             return retVal;
         }
 
-
+        /// <summary>
+        /// Fetch the hardware's MAC address from the DMA header in response to
+        /// the "special receive".  Store it in memory where the microcode will
+        /// transform it into the canonical 48-bit format we know and love.
+        /// </summary>
         void GetAddress(ulong nSkew, object context)
         {
             // Get the header address from DMA
             var addr = _system.IOB.DMARegisters.GetHeaderAddress(_dmaRx);
+            var words = _physAddr.Unscrambled(_system.IOB.IsEIO);
 
             Log.Debug(Category.Ethernet, "Writing machine address to 0x{0:x6}", addr);
 
-            // DMA the address bytes into the header buffer
-            _system.Memory.StoreWord(addr++, _physAddr.High);
-            _system.Memory.StoreWord(addr++, _physAddr.Mid);
-
-            // The low word's four nibbles are spread out like this:
-            _system.Memory.StoreWord(addr++, (ushort)((_physAddr.Hn << 12) | (_physAddr.MHn << 4)));
-            _system.Memory.StoreWord(addr, (ushort)((_physAddr.MLn << 12) | (_physAddr.Ln << 4)));
+            // DMA the unscrambled address bytes into the header buffer
+            for (var i = 0; i < words.Length; i++)
+            {
+                _system.Memory.StoreWord(addr++, words[i]);
+            }
 
             FinishCommand();
         }

--- a/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
+++ b/PERQemu/Emulator/IO/Network/Ether10MbitController.cs
@@ -149,63 +149,62 @@ namespace PERQemu.IO.Network
                 //
                 // Microsecond clock
                 //
-                case 0x88:      // OIO - Microsecond clock control
-                case 0xdc:      // EIO -      "        "      "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (control)", value);
+                case 0x88:      // OIO Microsecond clock control
+                case 0xdc:      // EIO
                     // Todo: actually run the clock!?
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (control)", value);
                     break;
 
-                case 0x89:      // OIO - uSec clock timer high byte
-                case 0xdd:      // EIO -  "     "     "    "    "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (high)", value);
+                case 0x89:      // OIO uSec clock timer high byte
+                case 0xdd:      // EIO
                     _usecClock = (ushort)((value << 8) | (_usecClock & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (high)", value);
                     break;
 
-                case 0x8a:      // OIO - uSec clock timer low byte
-                case 0xde:      // EIO -  "     "     "    "   "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (low)", value);
+                case 0x8a:      // OIO uSec clock timer low byte
+                case 0xde:      // EIO
                     _usecClock = (ushort)((_usecClock & 0xff00) | (value & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to usec clock (low)", value);
                     break;
 
                 //
                 // Bit counter 
                 //
-                case 0x8c:      // OIO - Bit counter control
-                case 0xd8:      // EIO -  "     "       "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (control)", value);
+                case 0x8c:      // OIO Bit counter control
+                case 0xd8:      // EIO
                     // Todo: Uh, actually do something?
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (control)", value);
                     break;
 
-                case 0x8d:      // OIO - Bit counter high byte
-                case 0xd9:      // EIO -  "     "     "    "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (high)", value);
+                case 0x8d:      // OIO Bit counter high byte
+                case 0xd9:      // EIO
                     _bitCount = (ushort)((value << 8) | (_bitCount & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (high)", value);
                     break;
 
-                case 0x8e:      // OIO - Bit counter low byte
-                case 0xda:      // EIO -  "     "     "   "
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (low)", value);
+                case 0x8e:      // OIO Bit counter low byte
+                case 0xda:      // EIO
                     _bitCount = (ushort)((_bitCount & 0xff00) | (value & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to bit counter (low)", value);
                     break;
 
                 //
                 // Receive address
                 //
-                case 0x90:      // OIO - Low word of MAC address
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x4} to low address register 0x{1:x2}", value, address);
-
+                case 0x90:      // OIO Low word of MAC address
                     // Have to byte swap this, because reasons
                     _recvAddr.Low = (ushort)(value << 8 | (value & 0xff00) >> 8);
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x4} to low address register 0x{1:x2}", value, address);
                     break;
 
-                case 0xc9:      // EIO - Low word of MAC address (5th octet)
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 5)", value & 0xff);
-                    _recvAddr.Low = (ushort)((value << 8) | (_recvAddr.Low & 0xff00));
+                case 0xc9:      // EIO Low word of MAC address (5th octet)
+                    _recvAddr.Low = (ushort)((value << 8) | (_recvAddr.Low & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 5)", value);
                     break;
 
-                case 0xc8:      // EIO - Low word of MAC address (6th octet)
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 6)", value & 0xff);
-                    _recvAddr.Low = (ushort)((_recvAddr.Low & 0x00ff) | (value & 0xff));
+                case 0xc8:      // EIO Low word of MAC address (6th octet)
+                    _recvAddr.Low = (ushort)((_recvAddr.Low & 0xff00) | (value & 0xff));
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to low address register (octet 6)", value);
                     break;
 
                 //
@@ -213,24 +212,28 @@ namespace PERQemu.IO.Network
                 // individually; on OIO, three 16-bit values are written and
                 // distributed to the MCB and group bytes (command + 5 groups)
                 //
-                case 0x91:      // OIO - Multicast Grp1|Cmd
-                case 0x92:      // OIO - Multicast Grp3|Grp2
-                case 0x93:      // OIO - Multicast Grp5|Grp4
+                case 0x91:      // OIO Multicast Grp1|Cmd
+                case 0x92:      // OIO Multicast Grp3|Grp2
+                case 0x93:      // OIO Multicast Grp5|Grp4
                     var offset = address - 0x91;
                     _mcastGroups[offset] = (byte)(value & 0xff);
                     _mcastGroups[offset + 1] = (byte)(value >> 8);
                     Log.Debug(Category.Ethernet, "Wrote 0x{0:x4} to multicast register 0x{1:x2}", value, address);
                     break;
 
-                case 0xca:      // EIO - Multicast command byte
-                case 0xcb:      // EIO - Multicast group 1
-                case 0xcc:      // EIO - Multicast group 2
-                case 0xcd:      // EIO - Multicast group 3
-                case 0xce:      // EIO - Multicast group 4
-                case 0xcf:      // EIO - Multicast group 5
+                case 0xca:      // EIO Multicast command byte
+                case 0xcb:      // EIO Multicast group 1
+                case 0xcc:      // EIO Multicast group 2
+                case 0xcd:      // EIO Multicast group 3
+                case 0xce:      // EIO Multicast group 4
+                case 0xcf:      // EIO Multicast group 5
                     var mcgb = address - 0xca;
                     _mcastGroups[mcgb] = (byte)(value & 0xff);
-                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to multicast register 0x{1:x2}", value, address);
+                    Log.Debug(Category.Ethernet, "Wrote 0x{0:x2} to multicast register {1} (0x{2:x2})", value, mcgb, address);
+                    break;
+
+                case 0xc3:
+                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to net interrupt enable reg", value);
                     break;
 
                 default:
@@ -312,16 +315,16 @@ namespace PERQemu.IO.Network
 
             switch (address)
             {
-                case 0x07:      // OIO - Read bit counter high byte
-                case 0x5b:      // EIO -  "    "     "     "    "
-                    retVal = (_bitCount >> 8) & 0xff;
-                    Log.Debug(Category.Ethernet, "Read 0x{0:x2} from bit counter (high)", retVal);
-                    return retVal;
-
-                case 0x06:      // OIO - Read bit counter low byte
-                case 0x5a:      // EIO -  "    "     "     "   "
+                case 0x06:      // OIO Read bit counter low byte
+                case 0x5a:      // EIO
                     retVal = (_bitCount & 0xff);
                     Log.Debug(Category.Ethernet, "Read 0x{0:x2} from bit counter (low)", retVal);
+                    return retVal;
+
+                case 0x07:      // OIO Read bit counter high byte
+                case 0x5b:      // EIO
+                    retVal = (_bitCount >> 8) & 0xff;
+                    Log.Debug(Category.Ethernet, "Read 0x{0:x2} from bit counter (high)", retVal);
                     return retVal;
 
                 default:

--- a/PERQemu/Emulator/IO/Network/Ether3MbitController.cs
+++ b/PERQemu/Emulator/IO/Network/Ether3MbitController.cs
@@ -47,7 +47,7 @@ namespace PERQemu.IO.Network
 
         public void LoadRegister(byte address, int value)
         {
-            throw new InvalidOperationException($"Unhandled write to port 0x{address:x}");
+            throw new UnhandledIORequestException(address, value);
         }
 
         public void LoadCommand(int value)
@@ -57,7 +57,7 @@ namespace PERQemu.IO.Network
 
         public int ReadRegister(byte address)
         {
-            throw new InvalidOperationException($"Unhandled read from port 0x{address:x}");
+            throw new UnhandledIORequestException(address);
         }
 
         public int ReadStatus()

--- a/PERQemu/Emulator/IO/Network/HostAdapter.cs
+++ b/PERQemu/Emulator/IO/Network/HostAdapter.cs
@@ -45,7 +45,7 @@ namespace PERQemu.IO.Network
 
             if (_adapter == null)
             {
-                throw new UnimplementedHardwareException("Host adapter not found");
+                throw new UnimplementedHardwareException("Host adapter not found (or not accessible)");
             }
 
             // Open the device and register our receive callback
@@ -75,6 +75,11 @@ namespace PERQemu.IO.Network
         {
             if (!Running)
             {
+                // If we just changed configuration, our own address may have changed;
+                // the table will get refreshed pretty quickly so this shouldn't be too
+                // disruptive (but make it a CLI option instead, if it is)
+                _nat.Flush();
+
                 // Add our local NAT entry
                 if (!_nat.Add(new NATEntry(_adapter.MacAddress, _controller.MACAddress, true)))
                 {
@@ -615,7 +620,7 @@ namespace PERQemu.IO.Network
                 }
             }
 
-            Log.Write("Could not find a match for Ethernet adapter '{0}'", name);
+            Log.Info(Category.NetAdapter, "Could not find a match for Ethernet adapter '{0}'", name);
             return null;
         }
 

--- a/PERQemu/Emulator/IO/Network/NullEthernet.cs
+++ b/PERQemu/Emulator/IO/Network/NullEthernet.cs
@@ -207,16 +207,16 @@ namespace PERQemu.IO.Network
                 case 0xcf:  // Grp5
                     offset = address - 0xca;
                     _mcastGroups[offset] = (byte)(~value & 0xff);
-                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to multicast register {1} (0x{2:x2})", value, offset, address);
+                    Log.Detail(Category.Ethernet, "Wrote 0x{0:x2} to multicast register {1} (0x{2:x2})", value, offset, address);
                     break;
 
                 // Interrupt enable register
                 case 0xc3:
-                    Log.Info(Category.Ethernet, "Wrote 0x{0:x2} to net interrupt enable reg", value);
+                    Log.Detail(Category.Ethernet, "Wrote 0x{0:x2} to net interrupt enable reg", value);
                     break;
 
                 default:
-                    throw new InvalidOperationException($"Unhandled write to port 0x{address:x}");
+                    throw new UnhandledIORequestException(address, value);
             }
         }
 
@@ -332,7 +332,7 @@ namespace PERQemu.IO.Network
                     return retVal;
 
                 default:
-                    throw new InvalidOperationException($"Unhandled write to port 0x{address:x}");
+                    throw new UnhandledIORequestException(address);
             }
         }
 
@@ -398,7 +398,7 @@ namespace PERQemu.IO.Network
             var addr = _system.IOB.DMARegisters.GetHeaderAddress(_dmaRx);
             var words = _physAddr.Unscrambled(_system.IOB.IsEIO);
 
-            Log.Info(Category.Ethernet, "Writing machine address to 0x{0:x6}", addr);
+            Log.Debug(Category.Ethernet, "Writing machine address to 0x{0:x6}", addr);
 
             // DMA the unscrambled address bytes into the header buffer
             for (var i = 0; i < words.Length; i++)

--- a/PERQemu/Emulator/IO/OIO.cs
+++ b/PERQemu/Emulator/IO/OIO.cs
@@ -97,9 +97,9 @@ namespace PERQemu.IO
         {
             _link.Reset();
 
-            if (_ethernet != null) _ethernet.Reset();
-            if (_streamer != null) _streamer.Reset();
-            if (_canon != null) _canon.Reset();
+            _ethernet?.Reset();
+            _streamer?.Reset();
+            _canon?.Reset();
 
             base.Reset();
         }

--- a/PERQemu/Emulator/IO/OIO.cs
+++ b/PERQemu/Emulator/IO/OIO.cs
@@ -182,9 +182,7 @@ namespace PERQemu.IO
                     return _link.ReadData();
 
                 default:
-                    // Log a warning for invalid or unknown port read attempts
-                    Log.Warn(Category.IO, "Unhandled OIO Read from port {0:x2}", port);
-                    break;
+                    throw new UnhandledIORequestException(port);
             }
 
             // Unhandled things assume this?
@@ -279,16 +277,13 @@ namespace PERQemu.IO
                     break;
 
                 default:
-                    Log.Warn(Category.IO, "Unhandled OIO Write to port {0:x2}, data {1:x4}", port, value);
-                    break;
+                    throw new UnhandledIORequestException(port, value);
             }
         }
 
-        public override uint Clock()
+        public override void Run()
         {
-            _link.Clock();
-
-            return 1;
+            _link?.Clock();
         }
 
         public override void Shutdown()

--- a/PERQemu/Emulator/IO/OptionBoard.cs
+++ b/PERQemu/Emulator/IO/OptionBoard.cs
@@ -45,6 +45,9 @@ namespace PERQemu.IO
             _sys = system;
         }
 
+        public static string Name => _name;
+        public static string Description => _desc;
+
         public bool HandlesPort(byte port)
         {
             return _portsHandled[port];
@@ -59,7 +62,26 @@ namespace PERQemu.IO
             Log.Info(Category.IO, "{0} board reset", _name);
         }
 
-        public abstract uint Clock();
+        public virtual void Run()
+        {
+            // Replaces Clock(), which only the Link used, and may again someday?
+            // If we ever get to Ether3Mbit, Multibus, Audre we'll consider if
+            // the Run/RunAsync/Stop approach that IOBoard uses is appropriate here
+        }
+
+        public virtual void Shutdown()
+        {
+            for (var p = 0; p < _portsHandled.Length; p++)
+            {
+                _portsHandled[p] = false;
+            }
+
+            Log.Detail(Category.Emulator, "OptionBoard shutdown.");
+        }
+
+        //
+        // IO Bus connection
+        //
 
         public abstract int IORead(byte port);
 
@@ -83,17 +105,6 @@ namespace PERQemu.IO
         {
         }
 
-        public virtual void Shutdown()
-        {
-            for (var p = 1; p < _portsHandled.Length; p++)
-                _portsHandled[p] = false;
-
-            Log.Detail(Category.Emulator, "OptionBoard shutdown.");
-        }
-
-        /// <summary>
-        /// Populate the port lookup table.
-        /// </summary>
         protected void RegisterPorts(byte[] ports)
         {
             foreach (var p in ports)
@@ -111,10 +122,10 @@ namespace PERQemu.IO
         protected static string _name;
         protected static string _desc;
 
-        // I/O port map for this board
-        static bool[] _portsHandled = new bool[256];
-
         // Parent
         protected PERQSystem _sys;
+
+        // I/O port map for this board
+        static bool[] _portsHandled = new bool[256];
     }
 }

--- a/PERQemu/Emulator/IO/PERQLink.cs
+++ b/PERQemu/Emulator/IO/PERQLink.cs
@@ -40,7 +40,6 @@ namespace PERQemu.IO
 
         public void Clock()
         {
-
 #if PERQLINK
             //
             // Synchronize the two processes in lockstep here.
@@ -92,13 +91,11 @@ namespace PERQemu.IO
             // reset latch
             _bufCycLatch = 0;
 
-#if TRACING_ENABLED
-           // if (Trace.TraceOn) Log.Debug(Category.Link, "PERQLink CSR read {0:x1}.", (value & 0xf));
-#endif
+            Log.Debug(Category.Link, "PERQLink CSR read {0:x1}.", (value & 0xf));
 
             return value;
 #else
-            return 0xff;    // Just indicate that nothing's there...
+            return 0xffff;    // Just indicate that nothing's there...
 #endif
         }
 
@@ -116,16 +113,14 @@ namespace PERQemu.IO
                 value = _linkData.DataDebugger;
             }
 
-#if TRACING_ENABLED
-                Log.Debug(Category.Link, "PERQLink Data debugger {0:x4}.", _linkData.DataDebugger);
-                Log.Debug(Category.Link, "PERQLink Data target {0:x4}.", _linkData.DataTarget);
-                Log.Debug(Category.Link, "PERQLink Data read {0:x4}.", value);
+            Log.Debug(Category.Link, "PERQLink Data debugger {0:x4}.", _linkData.DataDebugger);
+            Log.Debug(Category.Link, "PERQLink Data target {0:x4}.", _linkData.DataTarget);
+            Log.Debug(Category.Link, "PERQLink Data read {0:x4}.", value);
 
             if (value == 0x14e5)        // Hello
             {
                 Log.Debug(Category.Link, "Read HELLO!", value);
             }
-#endif
 
             return value;
 #else
@@ -136,9 +131,7 @@ namespace PERQemu.IO
         public void WriteCommandStatus(int value)
         {
 #if PERQLINK
-#if TRACING_ENABLED
-            // Log.Debug(Category.Link, "PERQLink CSR write {0:x1}.", (value & 0xf));
-#endif
+            Log.Debug(Category.Link, "PERQLink CSR write {0:x1}.", (value & 0xf));
 
             if (_linkData.EndPoint == Endpoint.Debugger)
             {
@@ -154,23 +147,20 @@ namespace PERQemu.IO
         public void WriteData(int value)
         {
 #if PERQLINK
-#if TRACING_ENABLED
-
             if (value == 0x14e5)        // Hello
             {
                 Log.Debug(Category.Link, "Wrote HELLO!", value);
             }
-#endif
 
             if (_linkData.EndPoint == Endpoint.Debugger)
             {
                 _linkData.DataDebugger = value;
-                // Log.Debug(Category.Link, "PERQLink Data write {0:x4}.", _linkData.DataDebugger);
+                Log.Debug(Category.Link, "PERQLink Data write {0:x4}.", _linkData.DataDebugger);
             }
             else
             {
                 _linkData.DataTarget = value;
-               // Log.Debug(Category.Link, "PERQLink Data write {0:x4}.", _linkData.DataTarget);
+                Log.Debug(Category.Link, "PERQLink Data write {0:x4}.", _linkData.DataTarget);
             }
 #endif
         }
@@ -179,8 +169,10 @@ namespace PERQemu.IO
         private SharedLinkData _linkData;
         private int _bufCycLatch;
 #endif
-        }
+    }
 
+
+#if PERQLINK
     /// <summary>
     /// Data marshalled to and from shared memory via SharedLinkData
     /// </summary>
@@ -199,7 +191,6 @@ namespace PERQemu.IO
         Debugger
     }
 
-#if PERQLINK
     /// <summary>
     /// Encapsulates win32 shared memory used to allow PERQLink to communicate between two processes,
     /// as well as a shared event for interlocking execution of the two processes.
@@ -423,7 +414,6 @@ namespace PERQemu.IO
             SectionNoCache = 0x10000000,
             SectionReserve = 0x4000000,
         }
-
     }
 #endif
 }

--- a/PERQemu/Emulator/IO/SerialDevices/SerialDevice.cs
+++ b/PERQemu/Emulator/IO/SerialDevices/SerialDevice.cs
@@ -135,7 +135,7 @@ namespace PERQemu.IO.SerialDevices
         // ICTCDevice implementation
         //
 
-        public virtual void NotifyRateChange(int newRate)
+        public virtual void NotifyRateChange(int chan, int newRate)
         {
             Log.Detail(Category.RS232, "Clock rate change to {0} ignored for {1}", newRate, Name);
         }

--- a/PERQemu/Emulator/IO/SerialDevices/SerialKeyboard.cs
+++ b/PERQemu/Emulator/IO/SerialDevices/SerialKeyboard.cs
@@ -50,7 +50,8 @@ namespace PERQemu.IO.SerialDevices
 
         public void QueueInput(byte key)
         {
-            Log.Detail(Category.Keyboard, "Queuing key '{0}' (0x{1:x2})", (char)key, key);
+            // Key bytes transmitted inverted; for logging, flip it back
+            Log.Detail(Category.Keyboard, "Queuing key '{0}' (0x{1:x2})", (char)(~key & 0x7f), key);
             _rxDelegate(key);
         }
 
@@ -66,7 +67,7 @@ namespace PERQemu.IO.SerialDevices
 
         public void TransmitBreak()
         {
-            throw new NotImplementedException();
+            Log.Detail(Category.Keyboard, "VT100 Keyboard received a Break?");
         }
 
 

--- a/PERQemu/Emulator/IO/SerialDevices/Speech.cs
+++ b/PERQemu/Emulator/IO/SerialDevices/Speech.cs
@@ -35,7 +35,7 @@ namespace PERQemu.IO.SerialDevices
         {
         }
 
-        public void NotifyRateChange(int newRate)
+        public void NotifyRateChange(int chan, int newRate)
         {
             throw new NotImplementedException();
         }

--- a/PERQemu/Emulator/IO/Z80/Am9519.cs
+++ b/PERQemu/Emulator/IO/Z80/Am9519.cs
@@ -290,8 +290,7 @@ namespace PERQemu.IO.Z80
             }
 
             // Shouldn't get here...
-            Log.Warn(Category.Z80IRQ, "Unhandled read from 0x{0:x2}, returning 0", portAddress);
-            return 0;
+            throw new UnhandledIORequestException(portAddress);
         }
 
 
@@ -441,10 +440,11 @@ namespace PERQemu.IO.Z80
                         throw new InvalidOperationException($"Bad command byte 0x{value:x2}");
                 }
 
+                // Normal completion
                 return;
             }
 
-            throw new InvalidOperationException($"Bad register write 0x{portAddress:x2}");
+            throw new UnhandledIORequestException(portAddress);
         }
 
         //

--- a/PERQemu/Emulator/IO/Z80/Am9519.cs
+++ b/PERQemu/Emulator/IO/Z80/Am9519.cs
@@ -18,44 +18,557 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace PERQemu.IO.Z80
 {
     /// <summary>
     /// The AMD Am9519 interrupt priority encoder, used by the EIO Z80.
     /// </summary>
+    /// <remarks>
+    /// On EIO the Z80 interrupt chain is a hybrid of two approaches:  both SIO
+    /// chips are directly wired to the Z80 INT line, with the other IRQ sources
+    /// managed by the Am9519 which can mask, prioritize and assert/acknowledge
+    /// interrupts on their behalf.  This keeps the EI->EO chain to just three
+    /// chips.  This implementation just uses the IZ80InterruptSource methods as
+    /// the Z80dotNet CPU does so controllers like the FDC and GPIB chips don't
+    /// have to "know" which board they're attached to!
+    /// </remarks>
     public class Am9519 : IZ80Device
     {
         public Am9519(byte baseAddress)
         {
             _baseAddress = baseAddress;
             _ports = new byte[] { _baseAddress, (byte)(_baseAddress + 1) };
+
+            _registers = new byte[4];
+
+            // Do initial allocation of the IRQ vector memory
+            _response = new ResponseRegister[8];
+
+            for (var i = 0; i < 8; i++)
+            {
+                _response[i].Device = null;
+                _response[i].ByteCount = 0;
+                _response[i].Counter = 0;
+                _response[i].Vector = new byte[4];
+            }
         }
 
         public string Name => "Am9519";
         public byte[] Ports => _ports;
 
-        // Fixme: placeholders until implemented so we can start debugging
-        public bool IntLineIsActive => false;
-        public byte? ValueOnDataBus => null;
+        public bool IntLineIsActive => _interruptEnabled;
+        public byte? ValueOnDataBus => GetActiveVector();
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }
 
         public void Reset()
         {
-            Log.Debug(Category.Z80IRQ, "Am9519 interrupt controller reset");
+            // At power up OR software reset
+            _mode = 0;
+            _status = 0;
+            _registers[IRR] = 0;
+            _registers[ISR] = 0;
+            _registers[ACR] = 0;
+            _registers[IMR] = 0xff;
+
+            _preselect = 0;
+            _loadVector = false;
+
+            // The Byte Count and Vector memory registers are explicitly NOT
+            // affected by reset and are unpredictable, must be initialized
+            // by the processor!
+
+            Log.Info(Category.Z80IRQ, "Am9519 interrupt controller reset");
+        }
+
+        /// <summary>
+        /// Receive handles from the devices that are hardwired to our IREQ/IACK
+        /// lines.  For EIO, these are the FDC, GPIB, FIFOs and DMA chip.
+        /// </summary>
+        public void RegisterDevice(IRQNumber source, IZ80Device dev)
+        {
+            _response[(int)source].Device = dev;
+            Log.Info(Category.Z80IRQ, "Registered device {0} at IRQ {1} ({2})",
+                                       dev.Name, (int)source, source);
+        }
+
+        /// <summary>
+        /// Check the status of the interrupt request lines.  This is going to be
+        /// painfully slow, polling them every cycle (which is what the Z80dotNet
+        /// CPU does for its list of sources?) but let's just see if it works,
+        /// before worrying about making it go fast.  At least this runs on the Z80
+        /// thread so it shouldn't bog down the main CPU?
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Clock()
+        {
+            // Scan the devices to see if anything requires attention.  This is
+            // magnificently ugly.  Profoundly grotesque.  Sublimely absurd.
+            IRQMask scan = 0;
+
+            if (_response[(int)IRQNumber.PERQDMA].Device?.IntLineIsActive ?? false) scan |= IRQMask.EndDMAInt;
+            if (_response[(int)IRQNumber.PERQInput].Device?.IntLineIsActive ?? false) scan |= IRQMask.PERQInt;
+            if (_response[(int)IRQNumber.PERQOutput].Device?.IntLineIsActive ?? false) scan |= IRQMask.RduProcData;
+            if (_response[(int)IRQNumber.Floppy].Device?.IntLineIsActive ?? false) scan |= IRQMask.FlopInt;
+            if (_response[(int)IRQNumber.GPIB].Device?.IntLineIsActive ?? false) scan |= IRQMask.GPIBInt;
+            if (_response[(int)IRQNumber.Z80DMA].Device?.IntLineIsActive ?? false) scan |= IRQMask.EOP;
+
+            if ((byte)scan != _registers[IRR])
+            {
+                Log.Info(Category.Z80IRQ, "Interrupt state change: {0}", scan);
+
+                // Save the new state
+                _registers[IRR] = (byte)scan;
+
+                // Update status so we can check flags
+                UpdateStatus();
+            }
+
+            // If "master arm" is not set or we're in polled mode, bug out
+            if (!_mode.HasFlag(ModeRegister.ChipArmed) || !_mode.HasFlag(ModeRegister.PolledMode))
+            {
+                _interruptEnabled = false;
+                return;
+            }
+
+            // Status register will contain the highest priority unmasked IRQ;
+            // check bit S7 to see if it's valid before checking priorities
+            if (_status.HasFlag(StatusRegister.NoGroupInt))
+            {
+                if (_interruptEnabled)
+                    Log.Info(Category.Z80IRQ, "No (further?) interrupts requested, disabling");
+
+                _interruptEnabled = false;
+                return;
+            }
+
+            if (_mode.HasFlag(ModeRegister.RotatingPriority))
+            {
+                Log.Info(Category.Z80IRQ, "Rotating priority not implemented");
+            }
+
+            // Set the active IRQ and raise the interrupt line
+            _active = (int)(_status & StatusRegister.PriorityMask);
+            _interruptEnabled = true;
+
+            Log.Info(Category.Z80IRQ, "Highest active interrupt now {0}", _active);
+        }
+
+        /// <summary>
+        /// Handles a request from the Z80 for an interrupt vector.  This simulates
+        /// the IACK pulse that lets the Am9519 know that the requesting device with
+        /// the highest interrupt priority is being serviced.
+        /// </summary>
+        public byte? GetActiveVector()
+        {
+            // If disabled or there are no outstanding requests, punt
+            if (!_interruptEnabled)
+            {
+                Log.Info(Category.Z80IRQ, "IACK with no outstanding request?");
+                return null;
+            }
+
+            // Clear the IRR bit for the active device, and set its ISR bit,
+            // unless the corresponding auto clear bit is on.  Got it?
+            ClearBit(IRR, (byte)_active);
+
+            if ((_registers[ACR] & (1 << _active)) != 0) SetBit(ISR, (byte)_active);
+
+            // The PERQ uses individual vectors, but check the mode bit just in case
+            if (_mode.HasFlag(ModeRegister.CommonVector))
+            {
+                Log.Info(Category.Z80IRQ, "Returning common vector 0x{0:x2}", _response[0].Vector[0]);
+                return _response[0].Vector[0];
+            }
+
+            // Touch the active device with our noodly appendage
+            if (_response[_active].Device != null)
+            {
+                Log.Info(Category.Z80IRQ, "IACK for device {0}, vector 0x{1:x2}",
+                                          _response[_active].Device.Name,
+                                          _response[_active].Vector[0]);
+
+                var ignore = _response[_active].Device.ValueOnDataBus;
+
+                // IN THEORY we can return up to four bytes of data, and we'd use
+                // our ByteCount and Counter fields to do that.  In practice, I'm
+                // just gonna cheat and rely on the knowledge that the PERQ/Z80
+                // only ever uses one byte responses.  Yes, this is bad and lazy.
+
+                // Return the programmed vector
+                return _response[_active].Vector[0];
+            }
+
+            // Whoops.  If we fell through, something went terribly wrong
+            Log.Warn(Category.Z80IRQ, "Unknown vector response for device {0}", _active);
+            return null;
         }
 
         public byte Read(byte portAddress)
         {
+            // if we read from the control register address, we get back the status reg?
+            // if we read from the data register, we get back the preselected (mode bits 5-6)
+            // internal register; vector response bytes are only sent in response to an iack
+            // (or when the Z80 requests our ValueOnDataBus
+
             Log.Debug(Category.Z80IRQ, "Read from 0x{0:x2}, returning 0 (unimplemented)", portAddress);
             return 0;
         }
 
         public void Write(byte portAddress, byte value)
         {
-            Log.Debug(Category.Z80IRQ, "Write 0x{0:x2} to port 0x{1:x2} (unimplemented)", value, portAddress);
+            Log.Detail(Category.Z80IRQ, "Write 0x{0:x2} to port 0x{1:x2}", value, portAddress);
+
+            if (portAddress == _baseAddress)
+            {
+                do
+                {
+                    if (_loadVector)
+                    {
+                        // Vector out of range, or byte count exceeded: fall through and blow up
+                        if (_preselect < 0 || _preselect > 7) break;
+                        if (_response[_preselect].Counter >= _response[_preselect].ByteCount) break;
+
+                        Log.Debug(Category.Z80IRQ, "Load vector {0} byte {1} = 0x{2:x2}",
+                                                    _preselect, _response[_preselect].Counter, value);
+
+                        // Save the byte and bump
+                        _response[_preselect].Vector[_response[_preselect].Counter++] = value;
+
+                        // Last one?
+                        if (_response[_preselect].Counter == _response[_preselect].ByteCount) _loadVector = false;
+                        return;
+                    }
+
+                    // Shouldn't/can't happen, but check anyway
+                    if (_preselect < ISR || _preselect > ACR) break;
+
+                    Log.Debug(Category.Z80IRQ, "Write 0x{0:x2} to {1} register", value,
+                                              (_preselect > 2) ? "ACR" :
+                                              (_preselect > 1) ? "IRR" :
+                                              (_preselect > 0) ? "IMR" : "ISR");
+
+                    _registers[_preselect] = value;
+                    return;
+
+                } while (true);     // I am not proud of this
+            }
+
+            if (portAddress == _baseAddress + 1)
+            {
+                // Command bytes have multiple formats, but the high nibble is
+                // unique for decoding purposes.  This is kinda goofy, AMD.
+                var cmd = (CommandPrefix)(value & 0xf0);
+
+                // Command byte
+                switch (cmd)
+                {
+                    case CommandPrefix.Reset:
+#if DEBUG
+                        if (value != 0)
+                        {
+                            Log.Warn(Category.Z80IRQ, "Illegal Am9519 reset command 0x{0:x2}", value);
+                        }
+#endif
+                        Reset();
+                        break;
+
+                    case CommandPrefix.ClearIRR_IMR:
+                        ClearBit(IRR, value);
+                        ClearBit(IMR, value);
+                        break;
+
+                    case CommandPrefix.ClearIRR:
+                        ClearBit(IRR, value);
+                        break;
+
+                    case CommandPrefix.ClearIMR:
+                        ClearBit(IMR, value);
+                        break;
+
+                    case CommandPrefix.ClearISR:
+                        ClearBit(ISR, value);
+                        break;
+
+                    case CommandPrefix.ClearHighISR:
+                        if (_registers[ISR] > 0)
+                        {
+                            for (byte b = 0; b < 8; b++)
+                            {
+                                if ((_registers[ISR] & (1 << b)) != 0)
+                                {
+                                    ClearBit(ISR, b);
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+
+                    case CommandPrefix.SetIRR:
+                        SetBit(IRR, value);
+                        break;
+
+                    case CommandPrefix.SetIMR:
+                        SetBit(IMR, value);
+                        break;
+
+                    case CommandPrefix.LoadMode40:
+                    case CommandPrefix.LoadMode41:
+                        SetBits(IMR, 0xe0, (byte)(value & 0x1f));
+                        break;
+
+                    case CommandPrefix.LoadMode65:
+                        var setClear = (byte)(value & 0x03);
+
+                        SetBits(IMR, 0x9f, (byte)((value & 0x0c) << 2));
+                        if (setClear == 1) SetBit(IMR, 7);
+                        if (setClear == 2) ClearBit(IMR, 7);
+#if DEBUG
+                        if (setClear == 3) Log.Warn(Category.Z80IRQ, "Illegal value in Load Mode command");
+#endif
+                        break;
+
+                    case CommandPrefix.SelectIMR:
+                        SetBits(IMR, 0x9f, (byte)ModeRegister.IMRSelect);   // DOES this set bits 6:5?
+                        _preselect = IMR;
+                        _loadVector = false;
+                        Log.Debug(Category.Z80IRQ, "Preselected IMR");
+                        break;
+
+                    case CommandPrefix.SelectAutoClr:
+                        SetBits(IMR, 0x9f, (byte)ModeRegister.AutoClear);   // check the docs carefully
+                        _preselect = ACR;
+                        _loadVector = false;
+                        Log.Debug(Category.Z80IRQ, "Preselected ACR");
+                        break;
+
+                    case CommandPrefix.LoadByteCnt0:
+                    case CommandPrefix.LoadByteCnt1:
+                        var count = (byte)(((value & 0x18) >> 3) + 1);  // count
+                        var regno = (byte)(value & 0x07);               // reg #
+                        _response[regno].ByteCount = count;             // save count
+                        _response[regno].Counter = 0;                   // reset
+                        _preselect = regno;                             // set flag
+                        _loadVector = true;
+                        Log.Debug(Category.Z80IRQ, "Preselected vector {0} ({1} bytes)", regno, count);
+                        break;
+
+                    default:
+                        throw new InvalidOperationException($"Bad command byte 0x{value:x2}");
+                }
+
+                UpdateStatus(); // debug?  Clock() and Read() will call us, right?
+                return;
+            }
+
+            throw new InvalidOperationException($"Bad register write 0x{portAddress:x2}");
         }
+
+        //
+        // Set or clear a bit or all bits based on the low nibble of a command byte.
+        //
+        void ClearBit(int reg, byte cmd)
+        {
+            var bit = (cmd & 0x7);
+
+            if ((cmd & 0x08) == 0)
+                _registers[reg] = 0;
+            else
+                _registers[reg] &= (byte)~(1 << bit);
+        }
+
+        void SetBit(int reg, byte cmd)
+        {
+            var bit = (cmd & 0x07);
+
+            if ((cmd & 0x08) == 0)
+                _registers[reg] = 0xff;
+            else
+                _registers[reg] |= (byte)(1 << bit);
+        }
+
+        void SetBits(int reg, byte mask, byte val)
+        {
+            _registers[reg] = (byte)((_registers[reg] & mask) | val);
+        }
+
+        /// <summary>
+        /// Update the status register.  Kind of expensive, but only needs updating
+        /// when read, not on every signal change?
+        /// </summary>
+        void UpdateStatus()
+        {
+            // Save current for logging
+            var ostatus = _status;
+
+            // Initialize with the highest unmasked bit that's set (regardless
+            // of our polling mode or current status?).
+            var highest = (byte)(_registers[IRR] & _registers[IMR]);
+
+            // Find the first set bit, starting from 0 (highest priority)
+            if (highest > 0)
+            {
+                _status = 0;
+
+                while ((highest & 0x1) == 0)
+                {
+                    _status++;
+                    highest >>= 1;
+                }
+            }
+            else
+            {
+                // No unmasked bits, so set bit 7 (bits 2:0 are irrelevant)
+                _status = StatusRegister.NoGroupInt;
+            }
+
+            // Bits 3-5 copied from the mode register, from different bit positions.  Oy vey, AMD.
+            _status |= _mode.HasFlag(ModeRegister.ChipArmed) ? StatusRegister.ChipArmed : 0;
+            _status |= _mode.HasFlag(ModeRegister.PolledMode) ? StatusRegister.PolledMode : 0;
+            _status |= _mode.HasFlag(ModeRegister.RotatingPriority) ? StatusRegister.RotatingPriority : 0;
+
+            // Bit 6, ChipEnabled, is that actual status of the hardware EI pin
+            // which, in our case, isn't available; we'd have to chain together
+            // the actual interrupt chain to determine which chip is active (and
+            // the Z80dotNet CPU's interrupt code isn't that precise).  For now,
+            // let's just assume that if we have any interrupts pending that we
+            // are enabled.  This is not ideal.
+            _status |= StatusRegister.ChipEnabled;      // "if (active)" or something
+
+            if (ostatus != _status)
+            {
+                Log.Info(Category.Z80IRQ, "Status change: {0} (prio {1})",
+                                          _status & ~StatusRegister.PriorityMask,
+                                          _status & StatusRegister.PriorityMask);
+            }
+        }
+
+        // Debugging
+        public void DumpStatus()
+        {
+            Console.WriteLine("Am9519 status:");
+            Console.WriteLine($"  Mode reg:   {_mode}");
+            Console.WriteLine($"  Status reg: {_status}");
+            Console.WriteLine($"  Interrupt:  {_interruptEnabled}  Active: {_active}");
+            Console.WriteLine("  IRR={0:x2} IMR={1:x2} ISR={2:x2} ACR={3:x2}",
+                              _registers[IRR], _registers[IMR], _registers[ISR], _registers[ACR]);
+            Console.WriteLine();
+            Console.WriteLine("Vectors:");
+
+            for (var i = 0; i < 8; i++)
+            {
+                if (_response[i].Device != null)
+                    Console.Write($"  {_response[i].Device.Name}={_response[i].Vector[0]:x2}");
+            }
+            Console.WriteLine();
+        }
+
+        [Flags]
+        enum StatusRegister : byte
+        {
+            // Bits 2:0 are a vector #
+            PriorityMask = 0x07,
+            ChipArmed = 0x08,
+            PolledMode = 0x10,
+            RotatingPriority = 0x20,
+            ChipEnabled = 0x40,
+            NoGroupInt = 0x80
+        }
+
+        [Flags]
+        enum ModeRegister : byte
+        {
+            RotatingPriority = 0x01,
+            CommonVector = 0x02,
+            PolledMode = 0x04,
+            GINTPolarityHi = 0x08,
+            IREQPolarityHi = 0x10,
+            ISRSelect = 0x00,
+            IMRSelect = 0x20,
+            IRRSelect = 0x40,
+            AutoClear = 0x60,
+            ChipArmed = 0x80
+        }
+
+        /// <summary>
+        /// Interrupt sources for the Am9519 in priority order (high to low).
+        /// Corresponds to the IREQ input pins on the chip.
+        /// </summary>
+        public enum IRQNumber
+        {
+            PERQDMA = 0,
+            PERQInput = 1,
+            PERQOutput = 2,
+            Floppy = 3,
+            GPIB = 4,
+            Z80DMA = 5
+        }
+
+        [Flags]
+        enum IRQMask : byte
+        {
+            EndDMAInt = 0x01,
+            PERQInt = 0x02,
+            RduProcData = 0x04,
+            FlopInt = 0x08,
+            GPIBInt = 0x10,
+            EOP = 0x20
+        }
+
+        /// <summary>
+        /// Upper nibble of a byte written to the command register.
+        /// </summary>
+        enum CommandPrefix : byte
+        {
+            Reset = 0x00,
+            ClearIRR_IMR = 0x10,
+            ClearIMR = 0x20,
+            SetIMR = 0x30,
+            ClearIRR = 0x40,
+            SetIRR = 0x50,
+            ClearHighISR = 0x60,
+            ClearISR = 0x70,
+            LoadMode40 = 0x80,
+            LoadMode41 = 0x90,
+            LoadMode65 = 0xa0,
+            SelectIMR = 0xb0,
+            SelectAutoClr = 0xc0,
+            LoadByteCnt0 = 0xe0,
+            LoadByteCnt1 = 0xf0
+        }
+
+        /// <summary>
+        /// Contains the internal byte count and vector response memory for a
+        /// single channel (plus some extra data for convenient grouping).
+        /// </summary>
+        protected struct ResponseRegister
+        {
+            public IZ80Device Device;       // Handle to the requesting device
+            public byte ByteCount;          // As programmed
+            public byte Counter;            // Counts cycles during a load/read
+            public byte[] Vector;           // Holds up to 4 response bytes
+        }
+
+        //
+        // Internal registers
+        //
+        const int ISR = 0;
+        const int IMR = 1;
+        const int IRR = 2;
+        const int ACR = 3;
+
+        byte[] _registers;
+        ModeRegister _mode;
+        StatusRegister _status;
+        ResponseRegister[] _response;
+
+        byte _preselect;    // Next register to load from data bus
+        bool _loadVector;   // Load to response memory?
+
+        bool _interruptEnabled;
+        int _active;
 
         byte _baseAddress;
         byte[] _ports;
@@ -111,5 +624,32 @@ namespace PERQemu.IO.Z80
     I.BY4       equ 18H     ; readback 4 bytes
 
     INTDATA     equ 140Q    ; Interrupt controller data
+
+startup sequence:
+Z80IRQ: Write 0x00 to port 0x61 (unimplemented)     reset
+Z80IRQ: Write 0x90 to port 0x61 (unimplemented)     load mode 4-0 with 00000
+Z80IRQ: Write 0xc0 to port 0x61 (unimplemented)     select autoclear
+Z80IRQ: Write 0xff to port 0x60 (unimplemented)     write all 1s to autoclear reg
+Z80IRQ: Write 0xe1 to port 0x61 (unimplemented)     select byte count (1) reg 1
+Z80IRQ: Write 0x14 to port 0x60 (unimplemented)     write vector byte 0x14 (perq input vec!)
+Z80IRQ: Write 0x19 to port 0x61 (unimplemented)     clear irr, imr bit 1 (perq int)
+Z80IRQ: Write 0xe2 to port 0x61 (unimplemented)     select byte count (1) reg 2
+Z80IRQ: Write 0x12 to port 0x60 (unimplemented)     write vector byte 0x12 (perq output vec)
+Z80IRQ: Write 0x1a to port 0x61 (unimplemented)     clear irr, imr bit 2 (rd uproc data)
+
+Z80DMA: Write 0x00 to port 0x3d (unimplemented)     dmac initialization?
+Z80DMA: Read from 0x38, returning 0 (unimplemented)
+Z80DMA: Write 0x60 to port 0x38 (unimplemented)
+
+Z80IRQ: Write 0xe5 to port 0x61 (unimplemented)     select byte count (1) reg 5
+Z80IRQ: Write 0x1a to port 0x60 (unimplemented)     write vector byte 0x1a (z80 dma eop)
+Z80IRQ: Write 0xe0 to port 0x61 (unimplemented)     select byte count (1) reg 0
+Z80IRQ: Write 0x10 to port 0x60 (unimplemented)     write vector byte 0x10 (perq dma)
+Z80IRQ: Write 0x10 to port 0x61 (unimplemented)     clear irr, imr bit 0 (end dma int)
+Z80IRQ: Write 0xe3 to port 0x61 (unimplemented)     select byte count (1) reg 3
+Z80IRQ: Write 0x16 to port 0x60 (unimplemented)     write vector byte 0x16 (floppy)
+Z80IRQ: Write 0xa1 to port 0x61 (unimplemented)     load mode 6-5 with 00, set 7 (master arm)
+
+[repeats first block - chip gets reset]
 
 */

--- a/PERQemu/Emulator/IO/Z80/Am9519.cs
+++ b/PERQemu/Emulator/IO/Z80/Am9519.cs
@@ -51,14 +51,14 @@ namespace PERQemu.IO.Z80
                 _response[i].Device = null;
                 _response[i].ByteCount = 0;
                 _response[i].Counter = 0;
-                _response[i].Vector = new byte[4];
+                _response[i].Vector = 0;
             }
         }
 
         public string Name => "Am9519";
         public byte[] Ports => _ports;
 
-        public bool IntLineIsActive => GetActiveInterrupt();
+        public bool IntLineIsActive => _interruptEnabled;
         public byte? ValueOnDataBus => GetActiveVector();
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }
@@ -74,7 +74,7 @@ namespace PERQemu.IO.Z80
             _registers[IMR] = 0xff;
 
             _regSelect = 0;
-            _active = 0;
+            _active = -1;
             _busy = false;
             _loadVector = false;
             _interruptEnabled = false;
@@ -83,7 +83,7 @@ namespace PERQemu.IO.Z80
             // affected by reset and are unpredictable, must be initialized
             // by the processor!
 
-            Log.Info(Category.Z80IRQ, "Am9519 interrupt controller reset");
+            Log.Debug(Category.Z80IRQ, "Am9519 interrupt controller reset");
         }
 
         /// <summary>
@@ -93,80 +93,87 @@ namespace PERQemu.IO.Z80
         public void RegisterDevice(IRQNumber source, IZ80Device dev)
         {
             _response[(int)source].Device = dev;
-            Log.Info(Category.Z80IRQ, "Registered device {0} at IRQ {1} ({2})",
+            Log.Debug(Category.Z80IRQ, "Registered device {0} at IRQ {1} ({2})",
                                        dev.Name, (int)source, source);
         }
 
         /// <summary>
-        /// Check the status of the interrupt request lines.  This is going to be
-        /// painfully slow, polling them every cycle (which is what the Z80dotNet
-        /// CPU does for its list of sources?) but let's just see if it works,
-        /// before worrying about making it go fast.  At least this runs on the Z80
-        /// thread so it shouldn't bog down the main CPU?
+        /// Check the status of the interrupt request lines and return true if a
+        /// device wants attention.  If so, sets the _active IRQ to the highest
+        /// priority requester.
+        /// <remarks>
+        /// </remarks>
+        /// To make this slightly less painful, we quickly bug out if any relevant
+        /// condition allows it.  If the _busy flag is set we don't scan for the
+        /// next device until the current interrupt handler returns (EIO Z80 does
+        /// a check for RETI explicitly).  This should cut down on extraneous polls
+        /// of every device's IntLineIsActive.  At least this runs on the Z80
+        /// thread so it shouldn't bog down the main CPU?  Can look for further
+        /// optimizations once it's working properly...
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool GetActiveInterrupt()
+        public void Clock()
         {
             // If "master arm" is not set or we're in polled mode, bug out
-            if (!_mode.HasFlag(ModeRegister.ChipArmed) || _mode.HasFlag(ModeRegister.PolledMode))
+            if (!_mode.HasFlag(ModeBits.ChipArmed) || _mode.HasFlag(ModeBits.PolledMode))
             {
                 _interruptEnabled = false;
-                return false;
+                return;
             }
 
-            // Do we want to allow nesting?  Keep it simple, for debugging:
+            // Keep it simple, for now, and don't allow nested interrupts; if the
+            // _busy flag is set we don't rescan until that clears
             if (_busy)
             {
-                return true;
+                _interruptEnabled = false;
+                return;
             }
 
-            // Scan the devices to see if anything requires attention.  This is
-            // magnificently ugly.  Profoundly grotesque.  Sublimely absurd.
-            IRQMask scan = 0;
+            // Not busy!  Scan the devices to see if anything requires attention
+            IRQMask scan = IRQMask.None;
 
-            if (_response[(int)IRQNumber.PERQDMA].Device?.IntLineIsActive ?? false) scan |= IRQMask.EndDMAInt;
-            if (_response[(int)IRQNumber.PERQtoZ80].Device?.IntLineIsActive ?? false) scan |= IRQMask.PERQInt;
-            if (_response[(int)IRQNumber.Z80toPERQ].Device?.IntLineIsActive ?? false) scan |= IRQMask.RduProcData;
-            if (_response[(int)IRQNumber.Floppy].Device?.IntLineIsActive ?? false) scan |= IRQMask.FlopInt;
-            if (_response[(int)IRQNumber.GPIB].Device?.IntLineIsActive ?? false) scan |= IRQMask.GPIBInt;
-            if (_response[(int)IRQNumber.Z80DMA].Device?.IntLineIsActive ?? false) scan |= IRQMask.EOP;
+            if (_response[(int)IRQNumber.PERQDMA].Device.IntLineIsActive) scan |= IRQMask.EndDMAInt;
+            if (_response[(int)IRQNumber.PERQtoZ80].Device.IntLineIsActive) scan |= IRQMask.PERQInt;
+            if (_response[(int)IRQNumber.Z80toPERQ].Device.IntLineIsActive) scan |= IRQMask.RduProcData;
+            if (_response[(int)IRQNumber.Floppy].Device.IntLineIsActive) scan |= IRQMask.FlopInt;
+            if (_response[(int)IRQNumber.GPIB].Device.IntLineIsActive) scan |= IRQMask.GPIBInt;
+            if (_response[(int)IRQNumber.Z80DMA].Device.IntLineIsActive) scan |= IRQMask.EOP;
 
+            // Any change?
             if ((byte)scan != _registers[IRR])
             {
-                Log.Info(Category.Z80IRQ, "Interrupt state change: {0}", scan);
+                Log.Debug(Category.Z80IRQ, "Interrupt state change: {0}", scan);
 
                 // Save the new state
                 _registers[IRR] = (byte)scan;
 
                 // Update status so we can check flags
                 UpdateStatus();
-            }
 
-            // Status register will contain the highest priority unmasked IRQ;
-            // check bit S7 to see if it's valid before checking priorities
-            if (_status.HasFlag(StatusRegister.NoGroupInt))
-            {
-                if (_interruptEnabled && !_busy)
+                // Status register will contain the highest priority unmasked IRQ;
+                // check bit S7 to see if it's valid before checking priorities.
+                // (This should be the only place we rely on this flag bit)
+                if (_status.HasFlag(StatusBits.NoGroupInt))
                 {
+                    if (_interruptEnabled || _active >= 0)
+                        Console.WriteLine($"NoGroupInt but int={_interruptEnabled} active={_active}?!?");
+
                     _interruptEnabled = false;
-                    Log.Info(Category.Z80IRQ, "No further interrupts requested, disabling");
+                    _active = -1;
                 }
+                else
+                {
+                    // Get the current highest priority bit (where 0 = highest)
+                    var highest = (int)(_status & StatusBits.PriorityMask);
 
-                return _interruptEnabled | _busy;
+                    // If already active, only bump according to the highest fixed
+                    // priority (i.e., lower numbered IRQ)
+                    _active = (_active < 0 ? highest : Math.Min(_active, highest));
+                    _interruptEnabled = true;
+
+                    Log.Debug(Category.Z80IRQ, "Highest active interrupt now {0}", _active);
+                }
             }
-
-            if (_mode.HasFlag(ModeRegister.RotatingPriority))
-            {
-                Log.Info(Category.Z80IRQ, "Rotating priority not implemented");
-            }
-
-            // Set the active IRQ and raise the interrupt line
-            _active = (int)(_status & StatusRegister.PriorityMask);
-            _busy = true;
-            _interruptEnabled = true;
-            Log.Info(Category.Z80IRQ, "Highest active interrupt now {0}", _active);
-
-            return _interruptEnabled;
         }
 
         /// <summary>
@@ -176,6 +183,7 @@ namespace PERQemu.IO.Z80
         /// </summary>
         public byte? GetActiveVector()
         {
+#if DEBUG
             // If disabled or there are no outstanding requests, punt
             if (!_interruptEnabled)
             {
@@ -183,23 +191,35 @@ namespace PERQemu.IO.Z80
                 return null;
             }
 
+            // Sanity check
+            if (_active < 0 || _active > 5)
+            {
+                Log.Info(Category.Z80IRQ, "IACK invalid request {0}?", _active);
+                return null;
+            }
+#endif
             // Eh, why not.  Assume if the Z80 is asking for our vector our
             // (virtual) EI pin is active.  I don't think anything cares.
-            _status |= StatusRegister.ChipEnabled;
+            _status |= StatusBits.ChipEnabled;
 
             // Clear the IRR bit for the active device, and set its ISR bit,
             // unless the corresponding auto clear bit is on.  Got it?
             SetBit(ISR, (byte)_active);
             ClearBit(IRR, (byte)_active);
 
-            Log.Info(Category.Z80IRQ, "IACK for device {0}, IRR={1:x2} ISR={2:x2}", _active,
-                                     _registers[IRR], _registers[ISR]);
+            Log.Debug(Category.Z80IRQ, "IACK for device {0}, IRR={1:x2} ISR={2:x2}", _active,
+                                       _registers[IRR], _registers[ISR]);
+
+            // Deassert the interrupt line and set Busy (so we don't reevaluate
+            // until RETI and avoid complicating things with nested interrupts)
+            _interruptEnabled = false;
+            _busy = true;
 
             // The PERQ uses individual vectors, but check the mode bit just in case
-            if (_mode.HasFlag(ModeRegister.CommonVector))
+            if (_mode.HasFlag(ModeBits.CommonVector))
             {
-                Log.Info(Category.Z80IRQ, "Returning common vector 0x{0:x2}", _response[0].Vector[0]);
-                return _response[0].Vector[0];
+                Log.Debug(Category.Z80IRQ, "Returning common vector 0x{0:x2}", _response[0].Vector);
+                return _response[0].Vector;
             }
 
             // Uh, I don't think this can happen
@@ -209,20 +229,15 @@ namespace PERQemu.IO.Z80
                 return null;
             }
 
-            Log.Info(Category.Z80IRQ, "Sending device {0} vector 0x{1:x2}",
+            Log.Debug(Category.Z80IRQ, "Sending device {0} vector 0x{1:x2}",
                                       _response[_active].Device.Name,
-                                      _response[_active].Vector[0]);
+                                      _response[_active].Vector);
 
             // Touch the active device with our noodly appendage
             var ignore = _response[_active].Device.ValueOnDataBus;
 
-            // IN THEORY we can return up to four bytes of data, and we'd use
-            // our ByteCount and Counter fields to do that.  In practice, I'm
-            // just gonna cheat and rely on the knowledge that the PERQ/Z80
-            // only ever uses one byte responses.  Yes, this is bad and lazy.
-
             // Return the programmed vector
-            return _response[_active].Vector[0];
+            return _response[_active].Vector;
         }
 
         /// <summary>
@@ -235,21 +250,16 @@ namespace PERQemu.IO.Z80
             // One of the SIOs might be active, but we aren't :-)
             if (!_busy) return;
 
-            // See if any ISR bits need to be autocleared
-            if (!_status.HasFlag(StatusRegister.NoGroupInt))
+            // If the active ISR and ACR bits are set, do the autoclear
+            var bit = 1 << _active;
+            if ((_registers[ISR] & bit) > 0 && (_registers[ACR] & bit) > 0)
             {
-                // See the the active ISR and ACR bits are set, and if so apply them
-                var bit = 1 << _active;
-                if ((_registers[ISR] & bit) > 0 && (_registers[ACR] & bit) > 0)
-                {
-
-                    ClearBit(ISR, _active);
-                    Log.Info(Category.Z80IRQ, "Autoclear active IRQ {0}", _active);
-                }
+                ClearBit(ISR, _active);
+                Log.Debug(Category.Z80IRQ, "Autoclear active IRQ {0}", _active);
             }
 
             _busy = false;
-            _interruptEnabled = false;
+            _active = -1;
             Log.Debug(Category.Z80IRQ, "RETI Acknowledge");
         }
 
@@ -297,7 +307,8 @@ namespace PERQemu.IO.Z80
                                                     _regSelect, _response[_regSelect].Counter, value);
 
                         // Save the byte and bump
-                        _response[_regSelect].Vector[_response[_regSelect].Counter++] = value;
+                        _response[_regSelect].Vector = value;   // Just the one...
+                        _response[_regSelect].Counter++;
 
                         // More to load?
                         _loadVector = (_response[_regSelect].Counter < _response[_regSelect].ByteCount);
@@ -380,6 +391,10 @@ namespace PERQemu.IO.Z80
                     case CommandPrefix.LoadMode40:
                     case CommandPrefix.LoadMode41:
                         SetModeBits(0xe0, (byte)(value & 0x1f));
+#if DEBUG
+                        if (_mode.HasFlag(ModeBits.RotatePriority))
+                            Log.Debug(Category.Z80IRQ, "Rotating priority not implemented");
+#endif                  
                         Log.Debug(Category.Z80IRQ, "Loaded mode register (lo): {0}", _mode);
                         break;
 
@@ -387,8 +402,8 @@ namespace PERQemu.IO.Z80
                         var setClear = (byte)(value & 0x03);
 
                         SetModeBits(0x9f, (byte)((value & 0xc0) << 3));
-                        if (setClear == 1) _mode |= ModeRegister.ChipArmed;
-                        if (setClear == 2) _mode &= ~(ModeRegister.ChipArmed);
+                        if (setClear == 1) _mode |= ModeBits.ChipArmed;
+                        if (setClear == 2) _mode &= ~(ModeBits.ChipArmed);
 #if DEBUG
                         if (setClear == 3) Log.Warn(Category.Z80IRQ, "Illegal value in Load Mode command");
 #endif
@@ -396,14 +411,12 @@ namespace PERQemu.IO.Z80
                         break;
 
                     case CommandPrefix.SelectIMR:
-                        //SetModeBits(0x9f, (byte)ModeRegister.IMRSelect);   // DOES this set bits 6:5?
                         _regSelect = IMR;
                         _loadVector = false;
                         Log.Debug(Category.Z80IRQ, "Preselected IMR");
                         break;
 
                     case CommandPrefix.SelectAutoClr:
-                        //SetModeBits(0x9f, (byte)ModeRegister.AutoClear);   // check the docs carefully
                         _regSelect = ACR;
                         _loadVector = false;
                         Log.Debug(Category.Z80IRQ, "Preselected ACR");
@@ -424,7 +437,6 @@ namespace PERQemu.IO.Z80
                         throw new InvalidOperationException($"Bad command byte 0x{value:x2}");
                 }
 
-                UpdateStatus(); // debug?  Clock() and Read() will call us, right?
                 return;
             }
 
@@ -459,12 +471,20 @@ namespace PERQemu.IO.Z80
         void SetModeBits(byte mask, byte val)
         {
             var tmp = (byte)_mode & mask;
-            _mode = (ModeRegister)(tmp | val);
+            _mode = (ModeBits)(tmp | val);
         }
 
         /// <summary>
-        /// Update the status register.  Kind of expensive, but only needs updating
-        /// when read, not on every signal change?
+        /// Update the status register, including the "highest priority IRR bit"
+        /// and the NoGroupInt flag.  This has the effect of doing a fixed IRQ
+        /// priority sweep (rotating priority mode isn't used by the PERQ so isn't
+        /// supported here).
+        /// <remarks>
+        /// </remarks>
+        /// This is kind of expensive and slightly horrible, but is only called
+        /// when the next active IRQ is needed or when the status register is read.
+        /// As it happens, the standard EIO Z80 firmware doesn't appear to ever
+        /// actually read it, apparently... 
         /// </summary>
         void UpdateStatus()
         {
@@ -488,27 +508,25 @@ namespace PERQemu.IO.Z80
             else
             {
                 // No unmasked bits, so set bit 7 (bits 2:0 are irrelevant)
-                _status = StatusRegister.NoGroupInt;
+                _status = StatusBits.NoGroupInt;
             }
 
             // Bits 3-5 copied from the mode register, from different bit positions.  Oy vey, AMD.
-            _status |= _mode.HasFlag(ModeRegister.ChipArmed) ? StatusRegister.ChipArmed : 0;
-            _status |= _mode.HasFlag(ModeRegister.PolledMode) ? StatusRegister.PolledMode : 0;
-            _status |= _mode.HasFlag(ModeRegister.RotatingPriority) ? StatusRegister.RotatingPriority : 0;
+            _status |= _mode.HasFlag(ModeBits.ChipArmed) ? StatusBits.ChipArmed : 0;
+            _status |= _mode.HasFlag(ModeBits.PolledMode) ? StatusBits.PolledMode : 0;
+            _status |= _mode.HasFlag(ModeBits.RotatePriority) ? StatusBits.RotatePriority : 0;
 
-            // Bit 6, ChipEnabled, is that actual status of the hardware EI pin
-            // which, in our case, isn't available; we'd have to chain together
-            // the actual interrupt chain to determine which chip is active (and
-            // the Z80dotNet CPU's interrupt code isn't that precise).  For now,
-            // let's just assume that if we have any interrupts pending that we
-            // are enabled.  This is not ideal.
-            _status |= _busy ? StatusRegister.ChipEnabled : 0;
+            // Bit 6, ChipEnabled, is the status of the chip's EI pin which, in
+            // our case, isn't available (we don't simulate the actual hardware
+            // interrupt chain).  For now, the _busy flag means we've IACK'ed an
+            // interrupt and are waiting for RETI, so that's close enough. :-)
+            _status |= _busy ? StatusBits.ChipEnabled : 0;
 
             if (ostatus != _status)
             {
-                Log.Info(Category.Z80IRQ, "Status change: {0} (prio {1})",
-                                          _status & ~StatusRegister.PriorityMask,
-                                          _status & StatusRegister.PriorityMask);
+                Log.Debug(Category.Z80IRQ, "Status change: {0} (prio {1})",
+                                          _status & ~StatusBits.PriorityMask,
+                                          _status & StatusBits.PriorityMask);
             }
         }
 
@@ -517,7 +535,7 @@ namespace PERQemu.IO.Z80
         {
             Console.WriteLine("Am9519 status:");
             Console.WriteLine($"  Mode reg:   {_mode}");
-            Console.WriteLine($"  Status reg: {_status}");
+            Console.WriteLine($"  Status reg: {(_status & ~StatusBits.PriorityMask)} ({(_status & StatusBits.PriorityMask)})");
             Console.WriteLine($"  Interrupt:  {_interruptEnabled}  Busy: {_busy}  Active IRQ: {_active}");
             Console.WriteLine("  IRR={0:x2} IMR={1:x2} ISR={2:x2} ACR={3:x2}",
                               _registers[IRR], _registers[IMR], _registers[ISR], _registers[ACR]);
@@ -527,27 +545,28 @@ namespace PERQemu.IO.Z80
             for (var i = 0; i < 8; i++)
             {
                 if (_response[i].Device != null)
-                    Console.Write($"  {_response[i].Device.Name}={_response[i].Vector[0]:x2}");
+                    Console.Write($"  {_response[i].Device.Name}={_response[i].Vector:x2}");
             }
             Console.WriteLine();
         }
 
+
         [Flags]
-        enum StatusRegister : byte
+        enum StatusBits : byte
         {
             // Bits 2:0 are a vector #
             PriorityMask = 0x07,
             ChipArmed = 0x08,
             PolledMode = 0x10,
-            RotatingPriority = 0x20,
+            RotatePriority = 0x20,
             ChipEnabled = 0x40,
             NoGroupInt = 0x80
         }
 
         [Flags]
-        enum ModeRegister : byte
+        enum ModeBits : byte
         {
-            RotatingPriority = 0x01,
+            RotatePriority = 0x01,
             CommonVector = 0x02,
             PolledMode = 0x04,
             GINTPolarityHi = 0x08,
@@ -576,6 +595,7 @@ namespace PERQemu.IO.Z80
         [Flags]
         enum IRQMask : byte
         {
+            None = 0x0,
             EndDMAInt = 0x01,
             PERQInt = 0x02,
             RduProcData = 0x04,
@@ -610,12 +630,17 @@ namespace PERQemu.IO.Z80
         /// Contains the internal byte count and vector response memory for a
         /// single channel (plus some extra data for convenient grouping).
         /// </summary>
+        /// <remarks>
+        /// While the chip can store and return up to four bytes of data for each
+        /// channel, the PERQ's Z80 only ever uses one byte responses.  So I've
+        /// simplified the code to just store and return a single byte.
+        /// </remarks>
         protected struct ResponseRegister
         {
             public IZ80Device Device;       // Handle to the requesting device
             public byte ByteCount;          // As programmed
             public byte Counter;            // Counts cycles during a load/read
-            public byte[] Vector;           // Holds up to 4 response bytes
+            public byte Vector;             // One byte for EIO Z80
         }
 
         //
@@ -625,11 +650,11 @@ namespace PERQemu.IO.Z80
         const int IMR = 1;
         const int IRR = 2;
         const int ACR = 3;
-        string[] R = { "ISR", "IMR", "IRR", "ACR" }; // debugging
+        string[] R = { "ISR", "IMR", "IRR", "ACR" };    // Debugging
 
         byte[] _registers;
-        ModeRegister _mode;
-        StatusRegister _status;
+        ModeBits _mode;
+        StatusBits _status;
         ResponseRegister[] _response;
 
         byte _regSelect;        // Next register to load from data bus
@@ -643,54 +668,3 @@ namespace PERQemu.IO.Z80
         byte[] _ports;
     }
 }
-
-/*
-    Notes:
-    
-    ;
-    ; Interrupt chip definitions
-    ;
-    INTCSR      equ 141Q    ; Interrupt controller control/status register
-    I.PDMA      equ 00H     ; DMA to/from PERQ done interrupt
-    I.PERQI     equ 01H     ; Data available in From PERQ FIFO
-    I.PERQO     equ 02H     ; Data just read from To PERQ FIFO
-    I.Floppy    equ 03H     ; Floppy interrupt
-    I.GPIB      equ 04H     ; GPIB interrupt
-    I.ZDMA      equ 05H     ; End of Process by DMA controller
-
-    I.Single    equ 08H     ; Select single level
-    I.CIMRIRR   equ 010H    ; Clear IMR and IRR
-    I.CIMR      equ 020H    ; Clear IMR
-    I.SIMR      equ 030H    ; Set IMR
-    I.CIRR      equ 040H    ; Clear IRR
-    I.SIRR      equ 050H    ; Set IRR
-    I.CHISR     equ 060H    ; Clear highest ISR bit
-    I.CISR      equ 070H    ; Clear ISR
-    I.M01234    equ 080H    ; Load mode bits 0..4
-    I.Fixed     equ 000H    ; Set for fixed priority
-    I.Rotate    equ 001H    ; Set for rotating priority
-    I.Indiv     equ 000H    ; Individual vectors
-    I.Common    equ 002H    ; Common vector for group
-    I.Interrupt equ 000H    ; Operate in interrupt move
-    I.Polled    equ 004H    ; Operate in polled mode
-    I.GrpLow    equ 000H    ; Group interrupt is active low
-    I.GrpHigh   equ 008H    ; Group interrupt is active low
-    I.ReqLow    equ 000H    ; Interrupt request is active low
-    I.ReqHigh   equ 010H    ; Interrupt request is active high
-    I.M567      equ 0A0H    ; Load Mode bits 5,6,7
-    I.Arm       equ 001H    ; Arm interrupt chip
-    I.DisArm    equ 002H    ; Disarm interrupt chip
-    I.RdISR     equ 000H    ; Preselect to read ISR
-    I.RdIMR     equ 004H    ; Preselect to read IMR
-    I.RdIRR     equ 008H    ; Preselect to read IRR
-    I.RdACR     equ 00CH    ; Preselect to read ACR
-    I.WrIMR     equ 0B0H    ; Select IMR
-    I.WrACR     equ 0C0H    ; Select ACR
-    I.WrRES     equ 0E0H    ; Select response memory
-    I.BY1       equ 00H     ; readback 1 byte
-    I.BY2       equ 08H     ; readback 2 bytes
-    I.BY3       equ 10H     ; readback 3 bytes
-    I.BY4       equ 18H     ; readback 4 bytes
-
-    INTDATA     equ 140Q    ; Interrupt controller data
-*/

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -69,8 +69,6 @@ namespace PERQemu.IO.Z80
             DeviceInit();
         }
 
-        public override bool IsEIO => false;
-
         // Expose to the DMA router
         public override Z80SIO SIOA => _z80sio;
 

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -77,9 +77,6 @@ namespace PERQemu.IO.Z80
         // Allow for external CTC triggers (disk seeks)
         public override Z80CTC CTC => _z80ctc;
 
-        // Do we need a wait state?
-        protected override bool FIFOInputReady => _perqToZ80Fifo.IsReady;
-        protected override bool FIFOOutputReady => _z80ToPerqFifo.IsReady;
 
         /// <summary>
         /// Initializes the IOB/CIO devices and attaches them to the bus.
@@ -307,7 +304,7 @@ namespace PERQemu.IO.Z80
 
             if (peek == 0xdba0 || peek == 0xedb2)
             {
-                if (!FIFOInputReady)
+                if (!_perqToZ80Fifo.IsReady)
                 {
                     Log.Debug(Category.FIFO, "Wait state for FIFO op ({0})",
                                               (peek == 0xdba0) ? "IN" : "INIR");
@@ -316,7 +313,7 @@ namespace PERQemu.IO.Z80
             }
             else if (peek == 0xd3d0 || (peek == 0xedb3 && regs.C == 0xd0))
             {
-                if (!FIFOOutputReady)
+                if (!_z80ToPerqFifo.IsReady)
                 {
                     Log.Debug(Category.FIFO, "Wait state for FIFO op ({0})",
                                               (peek == 0xd3d0) ? "OUT" : "OTIR");

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -84,14 +84,12 @@ namespace PERQemu.IO.Z80
             // Attach the configured tablet(s)
             if (_system.Config.Tablet.HasFlag(TabletType.BitPad))
             {
-                var tablet = new BitPadOne(_scheduler, _system);
-                _tms9914a.Bus.AddDevice(tablet);
+                _tms9914a.Bus.AddDevice(new BitPadOne(_scheduler, _system));
             }
 
             if (_system.Config.Tablet.HasFlag(TabletType.Kriz))
             {
-                var tablet = new KrizTablet(_scheduler, _system);
-                _z80sio.AttachDevice(1, tablet);
+                _z80sio.AttachDevice(1, new KrizTablet(_scheduler, _system));
             }
 
             // If enabled and configured, attach device to RS232

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -38,16 +38,18 @@ namespace PERQemu.IO.Z80
         public CIOZ80(PERQSystem system) : base(system)
         {
             // Set up the IOB/CIO peripherals
-            _fdc = new NECuPD765A(0xa8, _scheduler);
-            _tms9914a = new TMS9914A(0xb8);
             _seekControl = new HardDiskSeekControl(_system);
             _perqToZ80Fifo = new PERQToZ80Latch(_system);
             _z80ToPerqFifo = new Z80ToPERQLatch(_system);
-            _z80ctc = new Z80CTC(0x90, _scheduler);
-            _z80sio = new Z80SIO(0xb0, _scheduler);
+
+            _fdc = new NECuPD765A(0xa8, _scheduler);
+            _tms9914a = new TMS9914A(0xb8);
             _z80dma = new Z80DMA(0x98, _memory, _bus);
+            _z80ctc = new Z80CTC(0x90, _scheduler);
+            _z80sio = new Z80SIO(0xb0, this);
             _dmaRouter = new DMARouter(this);
             _keyboard = new Keyboard();
+
             _ioReg3 = new IOReg3(_perqToZ80Fifo, _keyboard, _fdc, _dmaRouter);
 
             // Initialize DMAC
@@ -66,6 +68,8 @@ namespace PERQemu.IO.Z80
 
             DeviceInit();
         }
+
+        public override bool IsEIO => false;
 
         // Expose to the DMA router
         public override Z80SIO SIOA => _z80sio;

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -324,11 +324,11 @@ namespace PERQemu.IO.Z80
             // Yes!  Run an instruction
             var ticks = _cpu.ExecuteNextInstruction();
 
+            // Run a DMA cycle (and account for the cycles used)
+            ticks += _z80dma.Clock();
+
             // Advance our wakeup time now so the CPU can chill a bit
             _wakeup = (long)(_scheduler.CurrentTimeNsec + ((ulong)ticks * IOBoard.Z80CycleTime));
-
-            // Run a DMA cycle
-            _z80dma.Clock();
 
             // Run the scheduler
             _scheduler.Clock(ticks);
@@ -362,6 +362,11 @@ namespace PERQemu.IO.Z80
         public override void DumpIRQStatus()
         {
             _bus.DumpInterrupts();
+        }
+
+        public override void DumpDMAStatus()
+        {
+            _z80dma.DumpStatus();
         }
 
 

--- a/PERQemu/Emulator/IO/Z80/CIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/CIOZ80.cs
@@ -67,11 +67,11 @@ namespace PERQemu.IO.Z80
             DeviceInit();
         }
 
-        // Allow for external CTC triggers (disk seeks)
-        public override Z80CTC CTC => _z80ctc;
-
         // Expose to the DMA router
         public override Z80SIO SIOA => _z80sio;
+
+        // Allow for external CTC triggers (disk seeks)
+        public override Z80CTC CTC => _z80ctc;
 
         // Do we need a wait state?
         protected override bool FIFOInputReady => _perqToZ80Fifo.IsReady;
@@ -118,16 +118,16 @@ namespace PERQemu.IO.Z80
             }
 
             // Everybody get on the bus!
-            _bus.RegisterDevice(_seekControl);
-            _bus.RegisterDevice(_perqToZ80Fifo);
-            _bus.RegisterDevice(_z80ToPerqFifo);
+            _bus.RegisterDevice(_fdc);
             _bus.RegisterDevice(_z80ctc);
             _bus.RegisterDevice(_z80sio);
             _bus.RegisterDevice(_z80dma);
-            _bus.RegisterDevice(_fdc);
             _bus.RegisterDevice(_tms9914a);
             _bus.RegisterDevice(_keyboard);
-            _bus.RegisterDevice(_ioReg3);
+            _bus.RegisterDevice(_perqToZ80Fifo);
+            _bus.RegisterDevice(_z80ToPerqFifo, false);
+            _bus.RegisterDevice(_seekControl, false);
+            _bus.RegisterDevice(_ioReg3, false);
         }
 
         protected override void DeviceReset()
@@ -357,6 +357,12 @@ namespace PERQemu.IO.Z80
         {
             Console.WriteLine($"{_system.Config.IOBoard} board does not have a serial port B.");
         }
+
+        public override void DumpIRQStatus()
+        {
+            _bus.DumpInterrupts();
+        }
+
 
         Z80SIO _z80sio;
         Z80CTC _z80ctc;

--- a/PERQemu/Emulator/IO/Z80/EIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/EIOZ80.cs
@@ -64,9 +64,6 @@ namespace PERQemu.IO.Z80
             DeviceInit();
         }
 
-        // Dorky but faster than "_sys is EIOZ80" everywhere?
-        public override bool IsEIO => true;
-
         // Port "A" is public, since it's a DMA-capable device
         public override Z80SIO SIOA => _z80sioA;
 

--- a/PERQemu/Emulator/IO/Z80/EIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/EIOZ80.cs
@@ -42,12 +42,12 @@ namespace PERQemu.IO.Z80
             _dmac = new i8237DMA(0x38, 0x30);
 
             // Set up the EIO peripherals
-            _tms9914a = new TMS9914A(0);
+            _tms9914a = new TMS9914A(0, 0x7b, 0x7c);
             _fdc = new NECuPD765A(0x20, _scheduler);
-            _z80sioA = new Z80SIO(0x10, _scheduler);
-            _z80sioB = new Z80SIO(0x40, _scheduler);
-            _timerA = new i8254PIT(0x50);
-            _timerB = new i8254PIT(0x54);
+            _z80sioA = new Z80SIO(0x10, this, "A");
+            _z80sioB = new Z80SIO(0x40, this, "B");
+            _timerA = new i8254PIT(0x50, "A");
+            _timerB = new i8254PIT(0x54, "B");
             _rtc = new Oki5832RTC(0x76);
 
             // Create our serial devices
@@ -60,6 +60,9 @@ namespace PERQemu.IO.Z80
 
             DeviceInit();
         }
+
+        // Dorky but faster than "_sys is EIOZ80" everywhere?
+        public override bool IsEIO => true;
 
         // Port "A" is public, since it's a DMA-capable device
         public override Z80SIO SIOA => _z80sioA;
@@ -100,13 +103,13 @@ namespace PERQemu.IO.Z80
                 {
                     var rsx = new RSXFilePort(this);
                     _z80sioA.AttachPortDevice(0, rsx);
-                    // _timerA.AttachDevice(0, rsx);
+                    _timerA.AttachDevice(0, rsx);
                 }
                 else
                 {
                     var rsa = new PhysicalPort(this, Settings.RSADevice, Settings.RSASettings, "A");
                     _z80sioA.AttachPortDevice(0, rsa);
-                    //_timerA.AttachDevice(0, rsa);  figure out how the PIT does it
+                    _timerA.AttachDevice(0, rsa);
                 }
             }
             else
@@ -122,13 +125,13 @@ namespace PERQemu.IO.Z80
                 {
                     var rsx = new RSXFilePort(this);
                     _z80sioB.AttachPortDevice(0, rsx);
-                    // _timerB.AttachDevice(0, rsx);
+                    _timerB.AttachDevice(0, rsx);
                 }
                 else
                 {
                     var rsb = new PhysicalPort(this, Settings.RSADevice, Settings.RSASettings, "B");
                     _z80sioB.AttachPortDevice(0, rsb);
-                    //_timerB.AttachDevice(0, rsb);  figure out how the PIT does it
+                    _timerB.AttachDevice(0, rsb);
                 }
             }
             else

--- a/PERQemu/Emulator/IO/Z80/EIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/EIOZ80.cs
@@ -79,14 +79,12 @@ namespace PERQemu.IO.Z80
             // Attach the configured tablet(s)
             if (_system.Config.Tablet.HasFlag(TabletType.BitPad))
             {
-                var tablet = new BitPadOne(_scheduler, _system);
-                _tms9914a.Bus.AddDevice(tablet);
+                _tms9914a.Bus.AddDevice(new BitPadOne(_scheduler, _system));
             }
 
             if (_system.Config.Tablet.HasFlag(TabletType.Kriz))
             {
-                var tablet = new KrizTablet(_scheduler, _system);
-                _z80sioA.AttachDevice(1, tablet);
+                _z80sioA.AttachDevice(1, new KrizTablet(_scheduler, _system));
             }
 
             // Attach the keyboard

--- a/PERQemu/Emulator/IO/Z80/EIOZ80.cs
+++ b/PERQemu/Emulator/IO/Z80/EIOZ80.cs
@@ -311,6 +311,12 @@ namespace PERQemu.IO.Z80
                 _system.MachineStateChange(WhatChanged.Z80RunState, _running);
             }
 
+            // Note: if bit 3 set, DMA address generation is disabled for the
+            // ExtA channel, which then drives the MADR lines directly.  So far
+            // none of the known optional I/O devices use that functionality.
+            // Audre?  MLO?  It seems very unlikely that emulating this feature
+            // will ever be needed.
+
             // Set the enable bits
             _perqToZ80Fifo.InterruptEnabled = ((status & 0x02) != 0);
             _z80ToPerqFifo.InterruptEnabled = ((status & 0x01) != 0);

--- a/PERQemu/Emulator/IO/Z80/ICTCDevice.cs
+++ b/PERQemu/Emulator/IO/Z80/ICTCDevice.cs
@@ -29,9 +29,10 @@ namespace PERQemu.IO.Z80
         /// <summary>
         /// Tell the device that the timer (baud rate clock) has changed.
         /// For PERQ-1 IOB/CIO, the Z80 CTC provides the baud clock (x16).
-        /// For PERQ-2 EIO, the i8254 chip does it [not yet implemented].
+        /// For PERQ-2 EIO, the i8254 chip does it.  We return the channel
+        /// number as the PERQ-2/EIO allows for separate Tx and Rx clocks,
+        /// even though the host probably does not.
         /// </summary>
-        void NotifyRateChange(int newRate);
-
+        void NotifyRateChange(int chan, int newRate);
     }
 }

--- a/PERQemu/Emulator/IO/Z80/NECuPD765A.cs
+++ b/PERQemu/Emulator/IO/Z80/NECuPD765A.cs
@@ -467,7 +467,7 @@ namespace PERQemu.IO.Z80
                 Log.Warn(Category.FloppyDisk, "Cylinder {0} is out of range!", cylinder);
 
                 _seekEnd = true;
-                _pcn[_unitSelect] = (byte)SelectedUnit.Geometry.Cylinders; // - 1?
+                _pcn[_unitSelect] = (byte)(SelectedUnit.Geometry.Cylinders - 1);
                 FinishCommand(true);
                 return;
             }
@@ -485,7 +485,6 @@ namespace PERQemu.IO.Z80
             SelectedUnit.SeekTo(cylinder, SeekCompleteCallback);
 
             PERQemu.Sys.MachineStateChange(WhatChanged.FloppyActivity, true);
-
         }
 
         void SeekCompleteCallback(ulong skewNsec, object context)

--- a/PERQemu/Emulator/IO/Z80/Oki5832RTC.cs
+++ b/PERQemu/Emulator/IO/Z80/Oki5832RTC.cs
@@ -234,27 +234,6 @@ namespace PERQemu.IO.Z80
 /*
     Notes:
 
-    ;
-    ;        Clock
-    ;
-    Clk.CSR     equ 166Q        ; Control register for clock
-    Clk.DATA    equ 167Q        ; Data register
-    ClkHold     equ 01000000B   ; Hold bit
-    ClkWrite    equ 00100000B   ; Write bit
-    ClkRead     equ 00010000B   ; Read bit
-    ClkY10      equ 0CH         ; Year 10s
-    ClkY1       equ 0BH         ; Year 1s
-    ClkMo10     equ 0AH         ; Month 10s
-    ClkMo1      equ 09H         ; Month 1s
-    ClkD10      equ 08H         ; Day 10s
-    ClkD1       equ 07H         ; Day 1s
-    ClkH10      equ 05H         ; Hour 10s
-    ClkH1       equ 04H         ; Hour 1s
-    ClkM10      equ 03H         ; Minute 10s
-    ClkM1       equ 02H         ; Minute 1s
-    ClkS10      equ 01H         ; Second 10s
-    ClkS1       equ 00H         ; Second 1s
-
     Note that the PERQ always selects 24-hour time and ignores the Day of Week
     register (6).  This chip only tracks 2-digit years, so it's not Y2K compliant.
 
@@ -281,4 +260,3 @@ namespace PERQemu.IO.Z80
     the number of "power on hours" increased... I mean, if you want a _true_
     emulation experience, it's the little details that matter!  :-]
  */
-

--- a/PERQemu/Emulator/IO/Z80/PERQDMA.cs
+++ b/PERQemu/Emulator/IO/Z80/PERQDMA.cs
@@ -122,8 +122,7 @@ namespace PERQemu.IO.Z80
 #endif
             }
 
-            Log.Warn(Category.DMA, "Unhandled read from port 0x{0:x2}", portAddress);
-            return 0;
+            throw new UnhandledIORequestException(portAddress);
         }
 
         /// <summary>
@@ -237,8 +236,7 @@ namespace PERQemu.IO.Z80
                     break;
 
                 default:
-                    Log.Warn(Category.DMA, "Unhandled write 0x{0:x2} to port 0x{1:x2}", value, portAddress);
-                    break;
+                    throw new UnhandledIORequestException(portAddress, value);
             }
         }
 

--- a/PERQemu/Emulator/IO/Z80/PERQDMA.cs
+++ b/PERQemu/Emulator/IO/Z80/PERQDMA.cs
@@ -1,0 +1,413 @@
+﻿//
+// PERQDMA.cs - Copyright (c) 2006-2024 Josh Dersch (derschjo@gmail.com)
+//
+// This file is part of PERQemu.
+//
+// PERQemu is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// PERQemu is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PERQemu.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+
+using PERQemu.Processor;
+
+namespace PERQemu.IO.Z80
+{
+    /// <summary>
+    /// Simulates the EIO's special PERQ-Z80 DMA channel.
+    /// </summary>
+    /// <remarks>
+    /// The custom EIO PERQ-Z80 DMA channel is a pair of 16-word deep FIFOs
+    /// *in addition to* and separate from the pair used for regular protocol
+    /// exchange between the two processors.  Here the PERQ side is read and
+    /// written as 16 bit words (four at a time) on the main memory buses by
+    /// the PERQ's DMA controller.  The Z80 side is accessed a byte-at-a-time
+    /// by the Z80's DMA controller.  This arrangement allows memory-to-memory
+    /// transfers with almost no software intervention.
+    /// </remarks>
+    public class PERQDMA : IZ80Device, IDMADevice
+    {
+        public PERQDMA(PERQSystem sys)
+        {
+            _system = sys;
+            _toZ80 = new Queue<byte>();
+            _toPerq = new Queue<ushort>();
+        }
+
+        public string Name => "PERQ-Z80 DMA";
+        public byte[] Ports => _ports;
+
+        public void Reset()
+        {
+            _z80IntRaised = false;
+            _highByte = false;
+            _start = false;
+            _holding = 0;
+            _address = 0;
+
+            _toZ80.Clear();
+            _toPerq.Clear();
+
+            _readReady = false;
+            _writeReady = false;
+
+            Log.Info(Category.DMA, "{0} reset", Name);
+        }
+
+        //
+        // Z80 Interrupts
+        //
+
+        public bool IntLineIsActive => _z80IntRaised;   // Hmm.  Problematic.
+        public byte? ValueOnDataBus => null;            // Supplied by the Am9519
+
+        public event EventHandler NmiInterruptPulse { add { } remove { } }
+
+        //
+        // Z80 DMA Interface
+        //
+
+        public bool ReadDataReady => _readReady;
+        public bool WriteDataReady => _writeReady;
+
+        public void DMATerminate()
+        {
+            _readReady = false;
+            _writeReady = false;
+            _z80IntRaised = true;
+            Log.Info(Category.DMA, "PDMA operation terminated");
+        }
+
+        //
+        // Z80 Bus Interface
+        //
+
+        /// <summary>
+        /// Z80 bus port for reading PDMA data from the PERQ since the Z80dotNet
+        /// CPU doesn't simulate bus requests from the DMAC.  This "fake" read
+        /// port gives the i8237 a device to read from when the PERQ is sending
+        /// data.  Port 165Q (0x75) is not used by the real hardware but may be
+        /// reassigned arbitrarily if any conflict is found with a real device.
+        /// </summary>
+        public byte Read(byte portAddress)
+        {
+            if (portAddress == 0x75)
+            {
+                // Assert: _dmaToPerq == false
+
+                // Fetch another quad?
+                if (_toZ80.Count % 8 == 0) Enqueue();
+
+                // If there's data it must be good :-)
+                if (_toZ80.Count > 1)
+                {
+                    byte val = _toZ80.Dequeue();
+                    Log.Info(Category.DMA, "Read 0x{0:x2} from PDMA FIFO", val);
+                    return val;
+                }
+#if DEBUG
+                // This can't happen... shut it down... 
+                if (_toZ80.Count == 0)
+                {
+                    Console.WriteLine("Read from empty FIFO!?");
+                    _readReady = false;
+                    return 0;
+                }
+#endif
+            }
+
+            Log.Warn(Category.DMA, "Unhandled read from port 0x{0:x2}", portAddress);
+            return 0;
+        }
+
+        /// <summary>
+        /// Z80 bus ports for managing the PERQ-Z80 DMA FIFOs:
+        ///     PDMAStart  equ 163Q    ; Force PERQ DMA cycle to fill/empty FiFos
+        ///     PDMAFlush  equ 164Q    ; Flush DMA FiFo to PERQ
+        ///     PDMADirect equ 172Q    ; 0 = DMA from PERQ, 1 = DMA to PERQ
+        /// 
+        /// Additionally, the fake port (0x75) can be written here too; see above.
+        /// </summary>
+        public void Write(byte portAddress, byte value)
+        {
+            switch (portAddress)
+            {
+                // Set direction bit
+                case 0x7a:
+                    //
+                    // This is called first when setting up a new operation.  Set
+                    // the start flag here so our first PERQ memory access (either
+                    // way) will load the starting address from the DMA registers.
+                    //
+                    _dmaToPerq = (value != 0);
+                    _start = true;
+                    _z80IntRaised = false;
+                    Log.Info(Category.DMA, "PDMA direction set to {0} ({1})", _dmaToPerq, value);
+                    break;
+
+                // Flush both FIFOs
+                case 0x74:
+                    //
+                    // Second step in the EIO firmware's standard setup, after the
+                    // direction is set.  If sending TO the PERQ we have to set an
+                    // initial _writeReady condition or the DMAC won't start things
+                    // rolling when the channel mask is reset.
+                    //
+                    _toZ80.Clear();
+                    _toPerq.Clear();
+
+                    if (_dmaToPerq) _writeReady = true;
+
+                    Log.Info(Category.DMA, "PDMA FIFOs flushed");
+                    break;
+
+                // Start (or finish!) a DMA transaction
+                case 0x73:
+                    if (_dmaToPerq)
+                    {
+                        //
+                        // This is actually called at the END of a transaction
+                        // (AFTER DMATerminate) to flush any residual bytes to
+                        // the PERQ.  At most there should only be one quad left
+                        // (or less) but loop until clear to be safe.
+                        //
+                        while (Dequeue(true)) { }
+
+                        Log.Write("Z80 to PERQ operation complete");
+                    }
+                    else
+                    {
+                        Log.Write("PERQ to Z80 operation starting");
+
+                        // Prime the _toZ80 FIFO with the first quad word
+                        Enqueue();
+
+                        // Tell the i8237 that we're ready to go
+                        _readReady = true;
+                    }
+                    break;
+
+                // "Fake" write data port
+                case 0x75:
+                    //
+                    // Reassemble two bytes from the Z80 into 16-bit words and
+                    // queue them up for the PERQ.
+                    //
+                    if (!_highByte)
+                    {
+                        _holding = value;
+                    }
+                    else
+                    {
+                        var word = (ushort)((_holding << 8) | value);
+                        _toPerq.Enqueue(word);
+
+                        Log.Info(Category.DMA, "Enqueued word 0x{0:x4} to PDMA FIFO (count {1})",
+                                                word, _toPerq.Count);
+                    }
+
+                    // Toggle our flipflop
+                    _highByte = !_highByte;
+
+                    // Tell the PERQ to dequeue if we have at least one quad's
+                    // worth (safe to call more frequently, but wasted overhead)
+                    if (_toPerq.Count >= 4) Dequeue();
+                    break;
+
+                default:
+                    Log.Warn(Category.DMA, "Unhandled write 0x{0:x2} to port 0x{1:x2}", value, portAddress);
+                    break;
+            }
+        }
+
+
+        //
+        // PERQ Interface
+        //
+
+        /// <summary>
+        /// Simulates the PERQ side of the DMA interface writing TO the Z80.
+        /// If there's room in the queue, loads another quad word into the Z80's
+        /// FIFO as 8 bytes and advances the address.
+        /// </summary>
+        void Enqueue()
+        {
+            // If there's no room at the inn, bail now
+            if (_toZ80.Count > 24) return;
+
+            // New transaction?
+            if (_start)
+            {
+                _address = _system.IOB.DMARegisters.GetDataAddress(ChannelName.uProc);
+                _start = false;
+            }
+
+            // Just log the start (and assume it's properly aligned)
+            Log.Write(Category.DMA, "Write 4 words to Z80 FIFO from addr 0x{0:x6}", _address);
+
+            // Queue up four more words for the Z80
+            for (int i = 0; i < 4; i++)
+            {
+                var value = _system.Memory.FetchWord(_address++);
+
+                // Todo: which order?
+                _toZ80.Enqueue((byte)value);
+                _toZ80.Enqueue((byte)((value >> 8) & 0xff));
+            }
+        }
+
+        /// <summary>
+        /// Reads (up to) four words from the Z80 and writes them to main memory,
+        /// advancing the address appropriately.  No-op if not enough words in
+        /// the queue, unless told to flush.  Returns true if there are unread
+        /// words in the FIFO.
+        /// </summary>
+        /// <remarks>
+        /// The PERQ DMA controller always writes quads; if the Z80 is a few words
+        /// short of a happy meal, I can only assume that the write to the "start"
+        /// register (per DMA.EIO source) forces the last good data to be padded
+        /// with whatever random bytes end up on the bus after the FIFO empties.
+        /// Here we just stop short rather than risk an overrun, although I assume
+        /// they always sized the buffers appropriately and that in practice short
+        /// transfers are from errors or deliberately cancelling an operation.
+        /// </remarks>
+        bool Dequeue(bool flush = false)
+        {
+            if (_start)
+            {
+                _address = _system.IOB.DMARegisters.GetDataAddress(ChannelName.uProc);
+                _start = false;
+            }
+
+            // Take up to one quad's worth
+            var count = _toPerq.Count > 4 ? 4 : _toPerq.Count;
+
+            // Bail out if we don't have enough and aren't flushing
+            if (count == 0) return false;
+            if (count < 4 && !flush) return true;
+
+            Log.Write(Category.DMA, "Read {0} words from PERQ FIFO to addr 0x{1:x6}", count, _address);
+
+            // Read and store a quad's worth from the Z80-to-PERQ queue
+            for (int i = 0; i < count; i++)
+            {
+                ushort value = _toPerq.Dequeue();
+                _system.Memory.StoreWord(_address++, value);
+            }
+
+            return _toPerq.Count > 0;
+        }
+
+
+        // Debugging
+        public void DumpFIFOs()
+        {
+            Console.WriteLine("PDMA Status:");
+            Console.WriteLine($"  Dir={_dmaToPerq}  Addr=0x{_address:x6}  Holding={_holding} (hi={_highByte})");
+            Console.WriteLine($"  ReadRdy={_readReady}  WriteRdy={_writeReady}  IRQ={_z80IntRaised}");
+            Console.WriteLine();
+
+            Console.Write("DMA to PERQ: ");
+
+            if (_toPerq.Count > 0)
+            {
+                var words = _toPerq.ToArray();
+                for (var i = 0; i < words.Length; i++)
+                    Console.Write($" 0x{words[i]:x4}");
+
+                Console.WriteLine();
+            }
+            else
+            {
+                Console.WriteLine("is empty.");
+            }
+
+            Console.Write("DMA to Z80:  ");
+
+            if (_toZ80.Count > 0)
+            {
+                var bytes = _toZ80.ToArray();
+                for (var i = 0; i < bytes.Length; i++)
+                    Console.Write($" 0x{bytes[i]:x2}");
+
+                Console.WriteLine();
+            }
+            else
+            {
+                Console.WriteLine("is empty.");
+            }
+        }
+
+        // Interrupt/DMA status
+        bool _z80IntRaised;
+
+        bool _dmaToPerq;
+        bool _highByte;
+        byte _holding;
+
+        bool _start;
+        int _address;
+
+        bool _readReady;
+        bool _writeReady;
+
+        Queue<byte> _toZ80;
+        Queue<ushort> _toPerq;
+
+        byte[] _ports = { 0x73, 0x74, 0x75, 0x7a };
+
+        PERQSystem _system;
+    }
+}
+
+/*
+    Notes:
+
+    This class fakes up the PERQ-Z80 DMA channel, consisting of a separate set
+    of 16-deep FIFOs that are wired into both DMA controllers.  This allows for
+    memory-to-memory transfers between the processors with virtually no CPU
+    intervention, and it allows the PERQ to dynamically load code into Z80 RAM
+    (as the ZBoot process in POS G does).  This means patches or new functions
+    can be added to the system without burning PROMs.  That's going to require
+    huge changes to how the Z80 Debugger works here... 
+    
+    Two interesting side effects of this arrangement as it pertains to emulation:
+
+        If it can run entirely on the Z80 thread that avoids concurrency issues;
+        because the PERQ side is "fake" (we don't actually implement the DMA
+        machinery faithfully) it means we assume that when the PERQ and Z80
+        are coordinating a transaction they DO NOT touch the memory locations
+        (in either memory space) until the DMA hardware's completion interrupts
+        fire.  This means no locking necessary!  Handwave!  Fingers crossed!
+        Wishful thinking!  LA LA LA LA LA I can't hear you neener neener
+
+        Secondly, because the PERQ's memory bus is so much faster than the
+        Z80's, I don't think any special timing or delays are needed; when
+        the Z80 initiates a read or write, we can literally just do the PERQ
+        memory accesses (always in quad words, so 8 bytes at a time) and 
+        push the data into the FIFOs; the regular Z80 DMA processing then
+        makes it seem like the hardware is doing it at the Z80's normal
+        speed, interleaved with instruction execution like any other DMAC
+        transaction.  All we miss is a handful of 680ns memory cycles that
+        might cause CPU stalls, but so far that's been acceptable for pretty
+        realistic emulation.  We can always revisit and refactor this once
+        the rest of the PERQ-2/EIO emulation is completed.  Functionality
+        first, performance and accuracy second. :-)
+
+    There are tons of unanswered or unexplored questions, but thankfully there
+    is enough source code around (and even a few helpful docs) to shed light on
+    how this works.  Because there are two sets of FIFOs, it would SEEM that
+    there could be data queued up in both directions at once, but I'm pretty
+    sure that's not how they're used in practice.  Will find out...
+ */

--- a/PERQemu/Emulator/IO/Z80/PERQDMA.cs
+++ b/PERQemu/Emulator/IO/Z80/PERQDMA.cs
@@ -46,8 +46,8 @@ namespace PERQemu.IO.Z80
         public string Name => "PERQ-Z80 DMA";
         public byte[] Ports => _ports;
 
-        public bool IntLineIsActive => false; // _z80IntRaised;   // Hmm.  Problematic?
-        public byte? ValueOnDataBus => null; // AckNull;         // Supplied by the Am9519
+        public bool IntLineIsActive => _z80IntRaised;   // Hmm.  Problematic?
+        public byte? ValueOnDataBus => AckNull;         // Supplied by the Am9519
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }
 
@@ -170,7 +170,7 @@ namespace PERQemu.IO.Z80
                     _writeReady = _dmaToPerq;
                     _z80IntRaised = false;
 
-                    Log.Info(Category.DMA, "PDMA FIFOs flushed");
+                    Log.Debug(Category.DMA, "PDMA FIFOs flushed");
                     break;
 
                 // Start (or finish!) a DMA transaction
@@ -186,11 +186,11 @@ namespace PERQemu.IO.Z80
                         while (Dequeue(true)) { }
 
                         _z80IntRaised = true;
-                        Log.Write("Z80 to PERQ operation complete");
+                        Log.Debug(Category.DMA, "Z80 to PERQ operation complete");
                     }
                     else
                     {
-                        Log.Write("PERQ to Z80 operation starting");
+                        Log.Debug(Category.DMA, "PERQ to Z80 operation starting");
 
                         // Prime the _toZ80 FIFO with the first quad word
                         Enqueue();

--- a/PERQemu/Emulator/IO/Z80/PERQToZ80FIFO.cs
+++ b/PERQemu/Emulator/IO/Z80/PERQToZ80FIFO.cs
@@ -59,8 +59,8 @@ namespace PERQemu.IO.Z80
 
         public string Name => "PERQ->Z80 FIFO";
         public byte[] Ports => _ports;
-        public byte? ValueOnDataBus => 0x14;    // PERQI.ISR
 
+        public byte? ValueOnDataBus => null;        // Supplied by the Am9519
         public bool IsReady => !_fifo.IsEmpty;
         public bool IntLineIsActive => _interruptEnabled && IsReady;
 

--- a/PERQemu/Emulator/IO/Z80/TMS9914A.cs
+++ b/PERQemu/Emulator/IO/Z80/TMS9914A.cs
@@ -47,8 +47,8 @@ namespace PERQemu.IO.Z80
 
             // For EIO, these are signals wired directly to the bus transceivers
             // but we handle them here (or ignore them, for now :-)
-            _ports[8] = SCaddr;
-            _ports[9] = PEaddr;
+            _ports[8] = SCaddr;     // GPControl  0 = Not controller, 1 = Controller
+            _ports[9] = PEaddr;     // GPTriState 0 = Open collector data, 1 = Tristate
 
             // Put ourselves on the bus!
             _bus.AddDevice(this);
@@ -102,6 +102,7 @@ namespace PERQemu.IO.Z80
 
         public string Name => "TMS9914A";
         public byte[] Ports => _ports;
+
         public byte? ValueOnDataBus => 0x22;            // GPIVEC (IOB/CIO)
         public bool IntLineIsActive => _interruptActive;
 

--- a/PERQemu/Emulator/IO/Z80/TMS9914A.cs
+++ b/PERQemu/Emulator/IO/Z80/TMS9914A.cs
@@ -40,15 +40,45 @@ namespace PERQemu.IO.Z80
     {
         public TMS9914A(byte baseAddr, byte SCaddr, byte PEaddr) : this(10)
         {
-            _baseAddress = baseAddr;
-
-            for (int i = 0; i < 8; i++)
-                _ports[i] = (byte)(baseAddr + i);
-
             // For EIO, these are signals wired directly to the bus transceivers
             // but we handle them here (or ignore them, for now :-)
-            _ports[8] = SCaddr;     // GPControl  0 = Not controller, 1 = Controller
-            _ports[9] = PEaddr;     // GPTriState 0 = Open collector data, 1 = Tristate
+            _scAddress = SCaddr;      // 0 = Not controller, 1 = Controller
+            _peAddress = PEaddr;      // 0 = Open collector, 1 = Tristate
+
+            // The 9914A defines a block of 8 R/W ports offset from a base address
+            _baseAddress = baseAddr;
+
+            // All of the port addresses to register with the Z80
+            for (var i = 0; i < 8; i++)
+            {
+                _allPorts[i] = (byte)(_baseAddress + i);
+            }
+            _allPorts[8] = _scAddress;
+            _allPorts[9] = _peAddress;
+
+            //
+            // Map the EIO read ports:
+            //
+            _rdPorts[0] = ReadRegister.IntStatus0;
+            _rdPorts[1] = ReadRegister.IntStatus1;
+            _rdPorts[2] = ReadRegister.AddressStatus;
+            _rdPorts[3] = ReadRegister.BusStatus;
+            _rdPorts[4] = ReadRegister.AddressSwitch;
+            _rdPorts[5] = ReadRegister.Illegal;
+            _rdPorts[6] = ReadRegister.CmdPassThrough;
+            _rdPorts[7] = ReadRegister.DataIn;
+
+            //
+            // EIO write ports:
+            //
+            _wrPorts[0] = WriteRegister.IntMask0;
+            _wrPorts[1] = WriteRegister.IntMask1;
+            _wrPorts[2] = WriteRegister.Illegal;
+            _wrPorts[3] = WriteRegister.AuxiliaryCmd;
+            _wrPorts[4] = WriteRegister.Illegal;
+            _wrPorts[5] = WriteRegister.Illegal;
+            _wrPorts[6] = WriteRegister.Illegal;
+            _wrPorts[7] = WriteRegister.DataOut;
 
             // Put ourselves on the bus!
             _bus.AddDevice(this);
@@ -60,8 +90,34 @@ namespace PERQemu.IO.Z80
         {
             _baseAddress = baseAddr;
 
-            for (int i = 0; i < 8; i++)
-                _ports[i] = (byte)(baseAddr + i);
+            for (var i = 0; i < 8; i++)
+            {
+                _allPorts[i] = (byte)(_baseAddress + i);
+            }
+
+            //
+            // IOB/CIO read ports:
+            //
+            _rdPorts[0] = ReadRegister.IntStatus0;
+            _rdPorts[1] = ReadRegister.AddressSwitch;
+            _rdPorts[2] = ReadRegister.AddressStatus;
+            _rdPorts[3] = ReadRegister.CmdPassThrough;
+            _rdPorts[4] = ReadRegister.IntStatus1;
+            _rdPorts[5] = ReadRegister.Illegal;
+            _rdPorts[6] = ReadRegister.BusStatus;
+            _rdPorts[7] = ReadRegister.DataIn;
+
+            //
+            // IOB/CIO write ports:
+            //
+            _wrPorts[0] = WriteRegister.IntMask0;
+            _wrPorts[1] = WriteRegister.Illegal;
+            _wrPorts[2] = WriteRegister.Illegal;
+            _wrPorts[3] = WriteRegister.Illegal;
+            _wrPorts[4] = WriteRegister.IntMask1;
+            _wrPorts[5] = WriteRegister.Illegal;
+            _wrPorts[6] = WriteRegister.AuxiliaryCmd;
+            _wrPorts[7] = WriteRegister.DataOut;
 
             // Put ourselves on the bus!
             _bus.AddDevice(this);
@@ -71,7 +127,10 @@ namespace PERQemu.IO.Z80
 
         protected TMS9914A(int portCount)
         {
-            _ports = new byte[portCount];
+            _allPorts = new byte[portCount];
+
+            _rdPorts = new ReadRegister[8];
+            _wrPorts = new WriteRegister[8];
 
             _rdRegisters = new byte[8];
             _wrRegisters = new byte[8];
@@ -82,8 +141,6 @@ namespace PERQemu.IO.Z80
             _bus = new GPIBBus();
             _busFifo = new Queue<ushort>();
         }
-
-        public byte DeviceID => 0;      // System Controller
 
         /// <summary>
         /// Hardware reset (power on or Z80 restart).
@@ -104,7 +161,7 @@ namespace PERQemu.IO.Z80
         }
 
         public string Name => "TMS9914A";
-        public byte[] Ports => _ports;
+        public byte[] Ports => _allPorts;
 
         public byte? ValueOnDataBus => 0x22;            // GPIVEC (IOB/CIO)
         public bool IntLineIsActive => _interruptActive;
@@ -112,6 +169,8 @@ namespace PERQemu.IO.Z80
         public event EventHandler NmiInterruptPulse { add { } remove { } }
 
         public GPIBBus Bus => _bus;
+
+        public byte DeviceID => 0;      // System Controller
 
         //
         // IDMADevice Interface
@@ -123,7 +182,7 @@ namespace PERQemu.IO.Z80
         public void DMATerminate()
         {
             // If we do single byte xfers, this is probably extraneous
-            Log.Info(Category.GPIB, "TMS9914A DMA terminate received");
+            Log.Debug(Category.GPIB, "TMS9914A DMA terminate received");
         }
 
         //
@@ -157,12 +216,13 @@ namespace PERQemu.IO.Z80
             _dmaWriteReady = _busFifo.Count == 0;
         }
 
+
         public byte Read(byte portAddress)
         {
-            var reg = portAddress - _baseAddress;
+            ReadRegister reg = _rdPorts[portAddress - _baseAddress];
             byte retval = 0;
 
-            switch ((ReadRegister)reg)
+            switch (reg)
             {
                 case ReadRegister.IntStatus0:
                     // To read the Interrupt Status 0 register, the INT0 and INT1
@@ -175,7 +235,7 @@ namespace PERQemu.IO.Z80
                     bool int1 = ((_rdRegisters[(int)ReadRegister.IntStatus1] &
                                   _wrRegisters[(int)WriteRegister.IntMask1]) != 0);
 
-                    retval = (byte)((_rdRegisters[reg] & 0x3f) |
+                    retval = (byte)((_rdRegisters[(int)reg] & 0x3f) |
                                     (int0 ? (byte)InterruptStatus0.Int0 : 0x0) |
                                     (int1 ? (byte)InterruptStatus0.Int1 : 0x0));
 
@@ -183,23 +243,23 @@ namespace PERQemu.IO.Z80
                     _rdRegisters[(int)ReadRegister.IntStatus0] &= (byte)~InterruptStatus0.BO;
                     _rdRegisters[(int)ReadRegister.IntStatus0] &= (byte)~InterruptStatus0.BI;
 
-                    Log.Debug(Category.GPIB, "Read 0x{0:x2} ({1}) from register {2}",
+                    Log.Debug(Category.GPIB, "Read 0x{0:x2} ({1}) from {2} register",
                                               retval, (InterruptStatus0)retval, reg);
                     AssertInterrupt();
-                    return retval;
+                    break;
 
                 case ReadRegister.AddressSwitch:
                 case ReadRegister.AddressStatus:
                 case ReadRegister.IntStatus1:
                 case ReadRegister.BusStatus:
-                    Log.Debug(Category.GPIB, "Read 0x{0:x2} from register {1}", _rdRegisters[reg], reg);
-                    return _rdRegisters[reg];
+                    Log.Debug(Category.GPIB, "Read 0x{0:x2} from {1} register", _rdRegisters[(int)reg], reg);
+                    return _rdRegisters[(int)reg];
 
                 case ReadRegister.CmdPassThrough:
                     // This just reads the data lines...
                     retval = (byte)(_busFifo.Count > 0 ? (_busFifo.Peek() >> 8) : 0x0);
                     Log.Debug(Category.GPIB, "Read 0x{0:x2} from register {1}", retval, reg);
-                    return retval;
+                    break;
 
                 case ReadRegister.DataIn:
                     // Retrieve the latest data byte from the bus
@@ -246,11 +306,13 @@ namespace PERQemu.IO.Z80
 
                     Log.Detail(Category.GPIB, "DataIn read 0x{0:x2} ({1} bytes remaining)", retval, _busFifo.Count);
                     AssertInterrupt();
-                    return retval;
+                    break;
 
-                default:
-                    throw new InvalidOperationException("Invalid port address on read");
+                case ReadRegister.Illegal:
+                    throw new InvalidOperationException($"Illegal port address 0x{portAddress:x} on GPIB register read");
             }
+
+            return retval;
         }
 
 
@@ -259,24 +321,26 @@ namespace PERQemu.IO.Z80
             // EIO has separate control registers for the 75160 and 75162 chips;
             // it makes sense to just include them here, rather than plumb in a
             // separate device.  For now, they're basically no-ops?
-            if (_ports.Length > 8)
+            if (_allPorts.Length > 8)
             {
-                if (portAddress == _ports[8])
+                if (portAddress == _scAddress)
                 {
-                    Log.Info(Category.GPIB, "SC pin set to {0}", value);
+                    Log.Debug(Category.GPIB, "SC pin set to {0}", value);
+                    // Uh, save this or do something with it...
                     return;
                 }
 
-                if (portAddress == _ports[9])
+                if (portAddress == _peAddress)
                 {
-                    Log.Info(Category.GPIB, "PE pin set to {0}", value);
+                    Log.Debug(Category.GPIB, "PE pin set to {0}", value);
+                    // No-op for now?
                     return;
                 }
 
-                // Otherwise it must be a regular write register
+                // Otherwise it's a regular register write
             }
 
-            var reg = (WriteRegister)(portAddress - _baseAddress);
+            WriteRegister reg = _wrPorts[portAddress - _baseAddress];
             _wrRegisters[(byte)reg] = value;
 
             switch (reg)
@@ -292,7 +356,10 @@ namespace PERQemu.IO.Z80
                 case WriteRegister.AddressRegister:
                 case WriteRegister.ParallelPoll:
                 case WriteRegister.SerialPoll:
-                    // Just note it for now, not sure what to do with these...
+                    // Just note it for now, not sure what to do with these, if anything?
+                    // The CIO/EIO rewrite doesn't even define them, and the PERQ may not
+                    // actually perform either Serial or Parallel polling (unless third-
+                    // party software maybe does it from Pascal?)
                     Log.Debug(Category.GPIB, "Wrote 0x{0:x2} to register {1}", value, reg);
                     break;
 
@@ -336,8 +403,8 @@ namespace PERQemu.IO.Z80
                     AssertInterrupt();
                     break;
 
-                default:
-                    throw new InvalidOperationException("Invalid port address on write");
+                case WriteRegister.Illegal:
+                    throw new InvalidOperationException($"Illegal port address 0x{portAddress:x} on GPIB register write");
             }
         }
 
@@ -626,6 +693,7 @@ namespace PERQemu.IO.Z80
             AddressStatus = 2,      // GPIAS
             CmdPassThrough = 3,     // GPICPT
             IntStatus1 = 4,         // GPIIS1
+            Illegal = 5,            // Not used
             BusStatus = 6,          // GPIBS
             DataIn = 7              // GPIIN
         }
@@ -634,11 +702,14 @@ namespace PERQemu.IO.Z80
         {
             IntMask0 = 0,           // GPIIM0
             AddressRegister = 1,    // GPIADD
+            Illegal = 2,            // Not used
             ParallelPoll = 3,       // GPIPP
             IntMask1 = 4,           // GPIIM1
             SerialPoll = 5,         // GPISP
             AuxiliaryCmd = 6,       // GPIAUX
-            DataOut = 7             // GPIOUT
+            DataOut = 7,            // GPIOUT
+            GPControl = 8,          // SC pin (EIO)
+            GPTriState = 9          // PE pin (EIO)
         }
 
         //
@@ -769,7 +840,12 @@ namespace PERQemu.IO.Z80
 
         // Registers
         byte _baseAddress;
-        byte[] _ports;
+        byte _scAddress;
+        byte _peAddress;
+
+        byte[] _allPorts;
+        ReadRegister[] _rdPorts;
+        WriteRegister[] _wrPorts;
 
         byte[] _rdRegisters;
         byte[] _wrRegisters;

--- a/PERQemu/Emulator/IO/Z80/TMS9914A.cs
+++ b/PERQemu/Emulator/IO/Z80/TMS9914A.cs
@@ -78,7 +78,7 @@ namespace PERQemu.IO.Z80
 
         public string Name => "TMS9914A";
         public byte[] Ports => _ports;
-        public byte? ValueOnDataBus => 0x22;    // GPIVEC
+        public byte? ValueOnDataBus => 0x22;            // GPIVEC (IOB/CIO)
         public bool IntLineIsActive => _interruptActive;
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }

--- a/PERQemu/Emulator/IO/Z80/Z80CTC.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80CTC.cs
@@ -425,7 +425,7 @@ namespace PERQemu.IO.Z80
                     // so that it can compute and set a baud rate for the external device...
                     if (TimerClient != null)
                     {
-                        TimerClient.NotifyRateChange(Counter);
+                        TimerClient.NotifyRateChange(Number, Counter);
                     }
                 }
 

--- a/PERQemu/Emulator/IO/Z80/Z80DMA.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80DMA.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace PERQemu.IO.Z80
 {
@@ -39,7 +40,10 @@ namespace PERQemu.IO.Z80
         {
             _memoryBus = memoryBus;
             _ioBus = ioBus;
+
             _baseAddress = baseAddress;
+            _ports = new byte[] { _baseAddress };
+
             _wr = new byte[7];
             _statusData = new Queue<byte>();
         }
@@ -73,8 +77,10 @@ namespace PERQemu.IO.Z80
         }
 
         public string Name => "Z80 DMA";
-        public byte[] Ports => new byte[] { _baseAddress };
-        public byte? ValueOnDataBus => _interruptVector;    // TODO: implement dynamic vector based on type
+        public byte[] Ports => _ports;
+
+        // Todo: implement dynamic vector based on type?
+        public byte? ValueOnDataBus => _interruptVector;
         public bool IntLineIsActive => _interruptEnabled && _interruptActive;
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }
@@ -89,21 +95,25 @@ namespace PERQemu.IO.Z80
             _deviceB = device;
         }
 
-        public void Clock()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int Clock()
         {
-            // TODO: handle "Interrupt on RDY" option
+            // Todo: handle "Interrupt on RDY" option?
 
             // If DMA is in progress, make it happen
             if (_enableDMA)
             {
-                _state = RunStateMachine();
+                return RunStateMachine();
             }
+
+            return 0;
         }
 
         /// <summary>
         /// Run the DMA state machine.  We have to split the transaction into
         /// two bus cycles because the Z80 can't do two memory/port operations
-        /// between instructions; data corruption results.
+        /// between instructions; data corruption results.  Returns the number
+        /// of clock cycles the operation required.
         /// </summary>
         /// <remarks>
         /// DANGER, Will Robinson!  This extremely simplistic first hack is to
@@ -113,9 +123,10 @@ namespace PERQemu.IO.Z80
         /// transaction this house of cards collapses.  If it solves the problem
         /// I'll figure out how to make it more robust...
         /// </remarks>
-        DMAState RunStateMachine()
+        int RunStateMachine()
         {
             DMAState nextState = _state;
+            var cycles = 0;
 
             // Only here if enabled, so jump right in
             if (_state == DMAState.Idle)
@@ -167,10 +178,12 @@ namespace PERQemu.IO.Z80
                         if (sourceIsIO)
                         {
                             _data = _ioBus[sourceAddress];
+                            cycles = 4;
                         }
                         else
                         {
                             _data = _memoryBus[sourceAddress];
+                            cycles = 3;
                         }
 
                         Log.Detail(Category.Z80DMA,
@@ -190,10 +203,12 @@ namespace PERQemu.IO.Z80
                         if (destIsIO)
                         {
                             _ioBus[destAddress] = _data;
+                            cycles = 4;
                         }
                         else
                         {
                             _memoryBus[destAddress] = _data;
+                            cycles = 3;
                         }
 
                         // Ready active
@@ -264,7 +279,9 @@ namespace PERQemu.IO.Z80
                     }
                     break;
             }
-            return nextState;
+
+            _state = nextState;
+            return cycles;
         }
 
         /// <summary>
@@ -583,6 +600,12 @@ namespace PERQemu.IO.Z80
             }
         }
 
+        // Debugging
+        public void DumpStatus()
+        {
+            Console.WriteLine("Z80 DMA status:  not available");
+        }
+
         enum DMAState
         {
             Idle = 0,
@@ -678,39 +701,43 @@ namespace PERQemu.IO.Z80
             new RegisterDecodes(0x83, 0x83)     // WR6
         };
 
-        Z80IOBus _ioBus;
-        Z80MemoryBus _memoryBus;
-        IDMADevice _deviceA;
-        IDMADevice _deviceB;
-        byte _baseAddress;
-
-        bool _writeBaseRegister;
-        int _baseRegister;
-
-        byte[] _wr;
-
-        ushort _portAddressAInit;
-        ushort _portAddressBInit;
-        ushort _blockLength;
-        byte _maskByte;
-        byte _matchByte;
-        byte _interruptControl;
-        byte _pulseControl;
-        byte _interruptVector;
-        byte _data;
 
         DMAState _state;
-        RR0 _status;
-        ReadMask _statusMask;
-        Queue<byte> _statusData;
-
-        bool _enableDMA;
-        bool _interruptActive;
-        bool _interruptEnabled;
+        IDMADevice _deviceA;
+        IDMADevice _deviceB;
 
         // Current port addresses
         ushort _portAddressA;
         ushort _portAddressB;
         ushort _byteCounter;
+
+        ushort _portAddressAInit;
+        ushort _portAddressBInit;
+        ushort _blockLength;
+
+        byte _data;
+        byte _maskByte;
+        byte _matchByte;
+        byte _pulseControl;
+        byte _interruptControl;
+        byte _interruptVector;
+
+        bool _enableDMA;
+        bool _interruptActive;
+        bool _interruptEnabled;
+
+        byte[] _wr;
+        bool _writeBaseRegister;
+        int _baseRegister;
+
+        RR0 _status;
+        ReadMask _statusMask;
+        Queue<byte> _statusData;
+
+        Z80IOBus _ioBus;
+        Z80MemoryBus _memoryBus;
+
+        byte _baseAddress;
+        byte[] _ports;
     }
 }

--- a/PERQemu/Emulator/IO/Z80/Z80DMA.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80DMA.cs
@@ -23,13 +23,12 @@ using System.Collections.Generic;
 namespace PERQemu.IO.Z80
 {
     /// <summary>
-    /// Implements most of the Z80 DMA controller.
+    /// Implements most of the PERQ-1 Z80 DMA controller.
     /// </summary>
     /// <remarks>
     /// The PERQ-1 IOB uses a Mostek MK3883N DMA chip (second source for the
     /// Zilog Z8410) which has one channel.  The PERQ-2 EIO uses the AMD Am9517
-    /// (aka Intel i8237) 4-channel DMA chip.  We'll have to refactor things so
-    /// each I/O Board loads its own DMA controller.
+    /// (aka Intel i8237) 4-channel DMA chip.
     /// 
     /// Under the "old Z80" (IOB) protocol, the read registers are not accessed,
     /// but apparently with the "new Z80" (CIO) they are!

--- a/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
@@ -61,8 +61,7 @@ namespace PERQemu.IO.Z80
                 if (_devices[d].IntLineIsActive)
                 {
                     if (!_status[d])
-                        Log.Debug(Category.Z80IRQ, "Device {0} raised, vector is {1:x2}",
-                                  _devices[d].Name, _devices[d].ValueOnDataBus);
+                        Log.Debug(Category.Z80IRQ, "Device {0} raised", _devices[d].Name);
                     _status[d] = true;
                 }
                 else

--- a/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
@@ -160,6 +160,8 @@ namespace PERQemu.IO.Z80
             try
             {
                 IZ80Device device = _devicePorts[port];
+                if (device == null) throw new UnhandledIORequestException((byte)port);
+
                 device.Write((byte)port, value);
 
                 Log.Debug(Category.Z80, "Write 0x{0:x} to port 0x{1:x} ({2})", value, port, device.Name);

--- a/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
@@ -74,6 +74,22 @@ namespace PERQemu.IO.Z80
             }
         }
 
+        // Debugging
+        public void DumpInterrupts()
+        {
+            var count = 0;
+
+            Console.WriteLine("Z80 active interrupts:");
+            for (var d = 0; d < _devices.Count; d++)
+            {
+                if (_devices[d].IntLineIsActive)
+                {
+                    Console.Write($"  {_devices[d].Name}");
+                    count++;
+                }
+            }
+            Console.WriteLine((count == 0) ? "  <none>" : "");
+        }
 
         //
         // IMemory Implementation
@@ -92,7 +108,7 @@ namespace PERQemu.IO.Z80
         //
         // Implementation
         //
-        public void RegisterDevice(IZ80Device device)
+        public void RegisterDevice(IZ80Device device, bool irqSource = true)
         {
             // Add to (the local copy of) the device list
             if (_devices.Contains(device))
@@ -112,8 +128,11 @@ namespace PERQemu.IO.Z80
                 _devicePorts[portAddress] = device;
             }
 
-            // Tell the Z80 about it
-            _z80System.CPU.RegisterInterruptSource(device);
+            if (irqSource)
+            {
+                // Tell the Z80 this device raises interrupts
+                _z80System.CPU.RegisterInterruptSource(device);
+            }
         }
 
         byte ReadPort(int port)

--- a/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80IOBus.cs
@@ -136,18 +136,20 @@ namespace PERQemu.IO.Z80
 
         byte ReadPort(int port)
         {
-            IZ80Device device = _devicePorts[port];
             byte value = 0xff;
 
-            if (device != null)
+            try
             {
+                IZ80Device device = _devicePorts[port];
+                if (device == null) throw new UnhandledIORequestException((byte)port);
+
                 value = device.Read((byte)port);
 
-                Log.Debug(Category.Z80, "Read 0x{0:x} from port 0x{1:x} ({2})", value, port, device.Name);
+                Log.Debug(Category.Z80, "Read 0x{0:x2} from port 0x{1:x2} ({2})", value, port, device.Name);
             }
-            else
+            catch (UnhandledIORequestException e)
             {
-                Log.Warn(Category.Z80, "Unhandled Read from port 0x{0:x}, returning 0xff", port);
+                Log.Warn(Category.Z80, e.Message);
             }
 
             return value;
@@ -155,17 +157,16 @@ namespace PERQemu.IO.Z80
 
         void WritePort(int port, byte value)
         {
-            IZ80Device device = _devicePorts[port];
-
-            if (device != null)
+            try
             {
+                IZ80Device device = _devicePorts[port];
                 device.Write((byte)port, value);
 
                 Log.Debug(Category.Z80, "Write 0x{0:x} to port 0x{1:x} ({2})", value, port, device.Name);
             }
-            else
+            catch (UnhandledIORequestException e)
             {
-                Log.Warn(Category.Z80, "Unhandled Write of 0x{0:x} to port 0x{1:x}", value, port);
+                Log.Warn(Category.Z80, e.Message);
             }
         }
 

--- a/PERQemu/Emulator/IO/Z80/Z80MemoryBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80MemoryBus.cs
@@ -66,7 +66,8 @@ namespace PERQemu.IO.Z80
         byte ReadByte(int address)
         {
 #if DEBUG
-            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address))
+            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address) &&
+                PERQemu.Sys.IOB.Z80System.IsRunning)
             {
                 byte val = (address < ROM_SIZE) ? _rom[address] : _ram[address - RAM_ADDRESS];
                 Console.WriteLine($"Z80 mem read: {address:x4} = {val:x2}");
@@ -90,7 +91,8 @@ namespace PERQemu.IO.Z80
         void WriteByte(int address, byte value)
         {
 #if DEBUG
-            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address))
+            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address) &&
+                PERQemu.Sys.IOB.Z80System.IsRunning)
             {
                 Console.WriteLine($"Z80 mem write: {address:x4} = {value:x2}");
                 PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.BreakpointReached(address);

--- a/PERQemu/Emulator/IO/Z80/Z80MemoryBus.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80MemoryBus.cs
@@ -23,7 +23,7 @@ using System;
 using System.IO;
 
 namespace PERQemu.IO.Z80
-{   
+{
     /// <summary>
     /// Z80MemoryBus implements the Konamiman Z80dotNet IMemory interface to
     /// provide access to the IO board's Z80 Memory space.
@@ -65,6 +65,14 @@ namespace PERQemu.IO.Z80
         //
         byte ReadByte(int address)
         {
+#if DEBUG
+            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address))
+            {
+                byte val = (address < ROM_SIZE) ? _rom[address] : _ram[address - RAM_ADDRESS];
+                Console.WriteLine($"Z80 mem read: {address:x4} = {val:x2}");
+                PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.BreakpointReached(address);
+            }
+#endif
             if (address < ROM_SIZE)
             {
                 return _rom[address];
@@ -75,21 +83,27 @@ namespace PERQemu.IO.Z80
                 return _ram[address - RAM_ADDRESS];
             }
 
-            // throw for now so I can see what's going on
+            // Throw for now so I can see what's going on
             throw new InvalidOperationException($"Unexpected memory read at address 0x{address:x}");
         }
 
         void WriteByte(int address, byte value)
         {
+#if DEBUG
+            if (PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.IsWatched(address))
+            {
+                Console.WriteLine($"Z80 mem write: {address:x4} = {value:x2}");
+                PERQemu.Sys.IOB.Z80System.Debugger.WatchedMemoryAddr.BreakpointReached(address);
+            }
+#endif
             if (address >= RAM_ADDRESS && address < RAM_ADDRESS + RAM_SIZE)
             {
                 _ram[address - RAM_ADDRESS] = value;
+                return;
             }
-            else
-            {
-                // throw for now so I can see what's going on
-                throw new InvalidOperationException($"Unexpected memory write at address 0x{address:x} of 0x{value:x}");
-            }
+
+            // Draw attention to scribbles outside the lines
+            throw new InvalidOperationException($"Unexpected memory write at address 0x{address:x} of 0x{value:x}");
         }
 
         public void DMATerminate()

--- a/PERQemu/Emulator/IO/Z80/Z80SIO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80SIO.cs
@@ -33,7 +33,7 @@ namespace PERQemu.IO.Z80
     /// </summary>
     public partial class Z80SIO : IZ80Device, IDMADevice
     {
-        public Z80SIO(byte baseAddress, Scheduler scheduler, bool isEio = false)
+        public Z80SIO(byte baseAddress, Scheduler scheduler)
         {
             _baseAddress = baseAddress;
             _ports = new byte[] {
@@ -47,7 +47,8 @@ namespace PERQemu.IO.Z80
             _channels[0] = new Channel(0, scheduler);
             _channels[1] = new Channel(1, scheduler);
 
-            _isEIO = isEio;
+            _isEIO = PERQemu.Config.Current.IOBoard == Config.IOBoardType.EIO ||
+                     PERQemu.Config.Current.IOBoard == Config.IOBoardType.NIO;
         }
 
         public void Reset()
@@ -150,15 +151,13 @@ namespace PERQemu.IO.Z80
                     return _channels[0].ReadData();
 
                 case 1:
-                    if (_isEIO)
-                        return _channels[1].ReadData();
-                    
+                    if (_isEIO) return _channels[1].ReadData();
+
                     return _channels[0].ReadRegister();
 
                 case 2:
-                    if (_isEIO)
-                        return _channels[0].ReadRegister();
-                    
+                    if (_isEIO) return _channels[0].ReadRegister();
+
                     return _channels[1].ReadData();
 
                 case 3:

--- a/PERQemu/Emulator/IO/Z80/Z80SIO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80SIO.cs
@@ -63,7 +63,7 @@ namespace PERQemu.IO.Z80
             _channels[0].Reset();
             _channels[1].Reset();
 
-            Log.Debug(Category.SIO, "Reset");
+            Log.Debug(Category.SIO, "Unit {0} reset", _unit);
         }
 
         public string Name => $"Z80 SIO {_unit}";

--- a/PERQemu/Emulator/IO/Z80/Z80SIO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80SIO.cs
@@ -31,10 +31,20 @@ namespace PERQemu.IO.Z80
     /// mapping register configuration to real hardware on the host).  Still a
     /// work in progress.
     /// </summary>
+    /// <remarks>
+    /// TODO: For EIO, take the opportunity to revisit and refactor the SIO to
+    /// do _all_ of the timing delays based on the PERQ's baud rate setting --
+    /// the client devices shouldn't have to mess with any of that.  RealPort
+    /// devices have the system's deep buffers; fake devices (RSX:) don't read
+    /// or write any faster than the SIO provides or accepts the data.  Having
+    /// the event scheduling in one place should make things cleaner.
+    /// </remarks>
     public partial class Z80SIO : IZ80Device, IDMADevice
     {
-        public Z80SIO(byte baseAddress, Scheduler scheduler)
+        public Z80SIO(byte baseAddress, Z80System sys, string unit = "A")
         {
+            _sys = sys;
+            _unit = unit;
             _baseAddress = baseAddress;
             _ports = new byte[] {
                                     baseAddress,
@@ -44,11 +54,8 @@ namespace PERQemu.IO.Z80
                                 };
 
             _channels = new Channel[2];
-            _channels[0] = new Channel(0, scheduler);
-            _channels[1] = new Channel(1, scheduler);
-
-            _isEIO = PERQemu.Config.Current.IOBoard == Config.IOBoardType.EIO ||
-                     PERQemu.Config.Current.IOBoard == Config.IOBoardType.NIO;
+            _channels[0] = new Channel(0, _sys.Scheduler);
+            _channels[1] = new Channel(1, _sys.Scheduler);
         }
 
         public void Reset()
@@ -59,7 +66,8 @@ namespace PERQemu.IO.Z80
             Log.Debug(Category.SIO, "Reset");
         }
 
-        public string Name => "Z80 SIO";
+        public string Name => $"Z80 SIO {_unit}";
+        public string Unit => _unit;
         public byte[] Ports => _ports;
 
         public bool IntLineIsActive
@@ -151,12 +159,12 @@ namespace PERQemu.IO.Z80
                     return _channels[0].ReadData();
 
                 case 1:
-                    if (_isEIO) return _channels[1].ReadData();
+                    if (_sys.IsEIO) return _channels[1].ReadData();
 
                     return _channels[0].ReadRegister();
 
                 case 2:
-                    if (_isEIO) return _channels[0].ReadRegister();
+                    if (_sys.IsEIO) return _channels[0].ReadRegister();
 
                     return _channels[1].ReadData();
 
@@ -181,14 +189,14 @@ namespace PERQemu.IO.Z80
                     break;
 
                 case 1:
-                    if (_isEIO)
+                    if (_sys.IsEIO)
                         _channels[1].WriteData(value);
                     else
                         _channels[0].WriteRegister(value);
                     break;
 
                 case 2:
-                    if (_isEIO)
+                    if (_sys.IsEIO)
                         _channels[0].WriteRegister(value);
                     else
                         _channels[1].WriteData(value);
@@ -213,6 +221,8 @@ namespace PERQemu.IO.Z80
 
         byte _baseAddress;
         byte[] _ports;
-        bool _isEIO;
+        string _unit;
+
+        Z80System _sys;
     }
 }

--- a/PERQemu/Emulator/IO/Z80/Z80SIOChannel.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80SIOChannel.cs
@@ -137,8 +137,8 @@ namespace PERQemu.IO.Z80
                 }
 
                 byte value = _readRegs[_selectedRegister];
-                Log.Debug(Category.SIO, "Channel {0} read 0x{1:x2} from register {2}",
-                                        _channelNumber, value, _selectedRegister);
+                Log.Detail(Category.SIO, "Channel {0} read 0x{1:x2} from register {2}",
+                                         _channelNumber, value, _selectedRegister);
                 return value;
             }
 
@@ -165,15 +165,15 @@ namespace PERQemu.IO.Z80
                 UpdateFlags();
 
                 Log.Debug(Category.SIO, "Channel {0} read data 0x{1:x2}, {2} remaining",
-                                            _channelNumber, data, _rxFifo.Count);
+                                        _channelNumber, data, _rxFifo.Count);
                 return data;
             }
 
 
             public void WriteRegister(byte value)
             {
-                Log.Debug(Category.SIO, "Channel {0} write 0x{1:x2} to register {2}",
-                                        _channelNumber, value, _selectedRegister);
+                Log.Detail(Category.SIO, "Channel {0} write 0x{1:x2} to register {2}",
+                                         _channelNumber, value, _selectedRegister);
 
                 _writeRegs[_selectedRegister] = value;
 
@@ -187,7 +187,7 @@ namespace PERQemu.IO.Z80
                     // Execute command:
                     var cmd = (WReg0Cmd)((value & 0x38) >> 3);
 
-                    Log.Debug(Category.SIO, "Channel {0} command is {1}", _channelNumber, cmd);
+                    Log.Detail(Category.SIO, "Channel {0} command is {1}", _channelNumber, cmd);
 
                     switch (cmd)
                     {
@@ -502,9 +502,9 @@ namespace PERQemu.IO.Z80
                 // PERQ may or may not even rely on this bit...
                 _readRegs[0] |= (byte)(InterruptLatched ? RReg0.IntPending : 0);
 
-                Log.Debug(Category.SIO, "Channel {0} RR0 = {1}", _channelNumber, (RReg0)_readRegs[0]);
-                Log.Debug(Category.SIO, "Channel {0} RR1 = {1}", _channelNumber, (RReg1)_readRegs[1]);
-                Log.Debug(Category.SIO, "Channel {0} IRQ status: Tx {1}/{2}, Rx {3}/{4}, Ext {5}/{6}, Vec {7}",
+                Log.Detail(Category.SIO, "Channel {0} RR0 = {1}", _channelNumber, (RReg0)_readRegs[0]);
+                Log.Detail(Category.SIO, "Channel {0} RR1 = {1}", _channelNumber, (RReg1)_readRegs[1]);
+                Log.Detail(Category.SIO, "Channel {0} IRQ status: Tx {1}/{2}, Rx {3}/{4}, Ext {5}/{6}, Vec {7}",
                           _channelNumber, _txInterruptLatched, TxInterruptEnabled,
                                           _rxInterruptLatched, RxInterruptEnabled,
                                           _extInterruptLatched, ExtInterruptEnabled, _interruptOffset);

--- a/PERQemu/Emulator/IO/Z80/Z80System.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80System.cs
@@ -55,6 +55,7 @@ namespace PERQemu.IO.Z80
         }
 
         public bool SupportsAsync => true;
+        public bool IsEIO => _system.IOB.IsEIO;
         public bool IsRunning => _running;
         public ulong Clocks => _cpu.TStatesElapsedSinceReset;
         public ulong Wakeup => (ulong)_wakeup;
@@ -67,7 +68,6 @@ namespace PERQemu.IO.Z80
         public NECuPD765A FDC => _fdc;
         public TMS9914A GPIB => _tms9914a;
 
-        public abstract bool IsEIO { get; }
         public abstract Z80SIO SIOA { get; }
         public abstract Z80CTC CTC { get; }
 
@@ -257,7 +257,7 @@ namespace PERQemu.IO.Z80
             Log.Debug(Category.Z80Inst, "{0}", state);
 
             // Write the whole thing
-            Console.WriteLine("{0}\n\t{1}+0x{2:x} : {3}", state, symbol, offset, source);
+            Console.WriteLine("{0}\n    {1}+{2}: {3}", state, symbol, offset, source);
         }
 
         /// <summary>

--- a/PERQemu/Emulator/IO/Z80/Z80System.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80System.cs
@@ -88,6 +88,7 @@ namespace PERQemu.IO.Z80
         public abstract void DumpPortAStatus();
         public abstract void DumpPortBStatus();
         public abstract void DumpIRQStatus();
+        public abstract void DumpDMAStatus();
 
 
         /// <summary>

--- a/PERQemu/Emulator/IO/Z80/Z80System.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80System.cs
@@ -80,9 +80,6 @@ namespace PERQemu.IO.Z80
         public abstract void Run();
         public abstract void QueueKeyboardInput(byte keyCode);
 
-        protected abstract bool FIFOInputReady { get; }
-        protected abstract bool FIFOOutputReady { get; }
-
         protected abstract void DeviceReset();
         protected abstract void DeviceShutdown();
 

--- a/PERQemu/Emulator/IO/Z80/Z80System.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80System.cs
@@ -67,6 +67,7 @@ namespace PERQemu.IO.Z80
         public NECuPD765A FDC => _fdc;
         public TMS9914A GPIB => _tms9914a;
 
+        public abstract bool IsEIO { get; }
         public abstract Z80SIO SIOA { get; }
         public abstract Z80CTC CTC { get; }
 
@@ -236,8 +237,8 @@ namespace PERQemu.IO.Z80
             if (_asyncThread != null)
             {
                 Console.WriteLine("Z80 thread is ID {0}, status {1}",
-                                  Thread.CurrentThread.ManagedThreadId,
-                                  Thread.CurrentThread.ThreadState);
+                                  _asyncThread.ManagedThreadId,
+                                  _asyncThread.ThreadState);
             }
         }
 

--- a/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
@@ -168,7 +168,7 @@ namespace PERQemu.IO.Z80
                     // signal is toggled off again when a different IOA address on
                     // the EIO is accessed.  This is a little bizarre and requires
                     // more study.
-                    _z80IntRaised = false;
+                    _z80IntRaised = _outputReady;
 
                     Log.Debug(Category.FIFO, "Z80 read FIFO status 0x{0:x}", result);
                     return result;

--- a/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
@@ -60,8 +60,8 @@ namespace PERQemu.IO.Z80
 
         public string Name => "Z80->PERQ FIFO";
         public byte[] Ports => _ports;
-        public byte? ValueOnDataBus => 0x12;        // TODO: PERQO.ISR ??
-        public bool IntLineIsActive => false;       // But it never interrupts?
+        public byte? ValueOnDataBus => null;        // Supplied by the Am9519
+        public bool IntLineIsActive => false;       // fixme for eio!
 
         public bool IsReady => _outputReady;
         public bool IsEmpty => _fifo.IsEmpty;

--- a/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
+++ b/PERQemu/Emulator/IO/Z80/Z80ToPERQFIFO.cs
@@ -41,6 +41,7 @@ namespace PERQemu.IO.Z80
             _lock = new object();
             _fifo = new Queue<byte>();
             _interruptEnabled = false;
+            _perqIntRaised = false;
             _outputReady = false;
         }
 
@@ -51,8 +52,7 @@ namespace PERQemu.IO.Z80
             _outputReady = false;
 
             // Dismiss the interrupts
-            _interruptEnabled = false;
-            _perqIntRaised = false;
+            InterruptEnabled = false;
             _z80IntRaised = false;
 
             Log.Debug(Category.FIFO, "{0} reset", Name);
@@ -195,6 +195,9 @@ namespace PERQemu.IO.Z80
                     // Control port: set or clear the output ready bit
                     _outputReady = ((value & 0x1) != 0);
                     Log.Debug(Category.FIFO, "Z80 output ready now {0}", _outputReady);
+
+                    // After a reset?
+                    _z80IntRaised = _outputReady;
 
                     // Fall through to fire the CPU interrupt if necessary
                 }

--- a/PERQemu/Emulator/IO/Z80/i8237DMA.cs
+++ b/PERQemu/Emulator/IO/Z80/i8237DMA.cs
@@ -30,7 +30,7 @@ namespace PERQemu.IO.Z80
     /// uses two blocks of addresses: control/status registers in one block,
     /// and four address/word count registers in a second.
     /// 
-    /// While programmable, these tend to be fixed on the EIO:
+    /// DREQ channel assignments are fixed on the EIO:
     ///     Chn 0 - Floppy      Chn 2 - SIO
     ///     Chn 1 - GPIB        Chn 3 - PERQ
     /// </remarks>
@@ -48,6 +48,9 @@ namespace PERQemu.IO.Z80
                 _ports[i] = (byte)(_controlBase + i);
                 _ports[i + 8] = (byte)(_channelBase + i);
             }
+
+            // Allocate our channels
+            _channels = new ChannelRegister[4];
         }
 
         public string Name => "i8237 DMA";
@@ -55,12 +58,23 @@ namespace PERQemu.IO.Z80
 
         // Fixme: placeholders until implemented so we can start debugging
         public bool IntLineIsActive => false;
-        public byte? ValueOnDataBus => null;
+        public byte? ValueOnDataBus => null;        // Supplied by the Am9519
 
         public event EventHandler NmiInterruptPulse { add { } remove { } }
 
         public void Reset()
         {
+            // Hardware reset or Master Clear command
+            _channels[0].Masked = true;
+            _channels[0].LowByte = true;
+            _channels[1].Masked = true;
+            _channels[1].LowByte = true;
+            _channels[2].Masked = true;
+            _channels[2].LowByte = true;
+            _channels[3].Masked = true;
+            _channels[3].LowByte = true;
+            _command = 0;
+            _temporary = 0;
             Log.Debug(Category.Z80DMA, "i8237 reset");
         }
 
@@ -69,16 +83,238 @@ namespace PERQemu.IO.Z80
             // Todo: Run the state machine!
         }
 
+        /// <summary>
+        /// Recompute the status register with current request and terminated
+        /// status of all four channels.
+        /// </summary>
+        void UpdateStatus()
+        {
+            var ostatus = _status;
+
+            // Just inline this for simplicity
+            _status = (byte)(_channels[0].Requested ? 0x01 : 0);
+            _status |= (byte)(_channels[0].Terminated ? 0x10 : 0);
+            _status |= (byte)(_channels[1].Requested ? 0x02 : 0);
+            _status |= (byte)(_channels[1].Terminated ? 0x20 : 0);
+            _status |= (byte)(_channels[2].Requested ? 0x04 : 0);
+            _status |= (byte)(_channels[2].Terminated ? 0x40 : 0);
+            _status |= (byte)(_channels[3].Requested ? 0x08 : 0);
+            _status |= (byte)(_channels[3].Terminated ? 0x80 : 0);
+
+            if (ostatus != _status)
+            {
+                Log.Info(Category.Z80DMA, "Status change: 0x{0:x2}", _status);  // todo: a toBinary() might be nice here
+            }
+        }
+
+
         public byte Read(byte portAddress)
         {
-            Log.Debug(Category.Z80DMA, "Read from 0x{0:x2}, returning 0 (unimplemented)", portAddress);
+            if (portAddress == _controlBase)
+            {
+                UpdateStatus();
+
+                byte save = _status;
+                Log.Debug(Category.Z80DMA, "Read 0x{0:x2} from status register", save);
+
+                // Reading status clears the EOP bits (S3..S0)!
+                _status &= 0xf0;
+
+                return save;
+            }
+
+            if (portAddress == _controlBase + 5)
+            {
+                Log.Debug(Category.Z80DMA, "Read 0x{0:x2} from temporary reg", _temporary);
+                return _temporary;
+            }
+
+            if (portAddress >= _channelBase && portAddress <= _channelBase + 7)
+            {
+                // Compute channel #
+                var chan = (portAddress - _channelBase) / 2;
+                var addr = (portAddress & 0x1) == 0;
+                ushort val = 0;
+                byte half = 0;
+
+                // Even port is current address, odd port is current word count
+                if (addr)
+                {
+                    val = _channels[chan].CurrentAddress;
+                    half = (_channels[chan].LowByte ? (byte)val : (byte)(val >> 8));
+                }
+                else
+                {
+                    val = _channels[chan].CurrentCount;
+                    half = (_channels[chan].LowByte ? (byte)val : (byte)(val >> 8));
+                }
+
+                // Log it
+                Log.Info(Category.Z80DMA, "Read 0x{0:x2} from channel {1} current {2} ({3} byte)",
+                                          half, chan,
+                                          (addr ? "address" : "word count"),
+                                          (_channels[chan].LowByte ? "low" : "high"));
+
+                // Toggle the flip flop for the next read
+                _channels[chan].LowByte = !_channels[chan].LowByte;
+                return half;
+            }
+
+            Log.Warn(Category.Z80DMA, "Bad read from port 0x{0:x2} (illegal address)", portAddress);
+            // throw ...
             return 0;
         }
 
+
         public void Write(byte portAddress, byte value)
         {
-            Log.Debug(Category.Z80DMA, "Write 0x{0:x2} to port 0x{1:x2} (unimplemented)", value, portAddress);
+            var chan = 0;
+
+            // Channel data?
+            if (portAddress >= _channelBase && portAddress <= _channelBase + 7)
+            {
+                chan = (portAddress - _channelBase) / 2;
+                var addr = (portAddress & 0x1) == 0;
+
+                // Address or word count?
+                if (addr)
+                {
+                    // Low byte assigns/clears high, high byte adds
+                    if (_channels[chan].LowByte)
+                        _channels[chan].BaseAddress = value;
+                    else
+                        _channels[chan].BaseAddress += (ushort)(value << 8);
+
+                    // The Current counter is loaded in parallel!
+                    _channels[chan].CurrentAddress = _channels[chan].BaseAddress;
+                }
+                else
+                {
+                    // As above, for the word counter
+                    if (_channels[chan].LowByte)
+                        _channels[chan].WordCount = value;
+                    else
+                        _channels[chan].WordCount += (ushort)(value << 8);
+
+                    _channels[chan].CurrentCount = _channels[chan].WordCount;
+                }
+
+                Log.Info(Category.Z80DMA, "Write 0x{0:x2} to channel {1} {2} ({3} byte)",
+                                          value, chan,
+                                          (addr ? "base address" : "word count"),
+                                          (_channels[chan].LowByte ? "low" : "high"));
+
+                // Toggle the flip flop for the next write
+                _channels[chan].LowByte = !_channels[chan].LowByte;
+                return;
+            }
+
+            // Command write
+            var cmd = (portAddress - _controlBase);
+            chan = (value & 0x03);      // channel select for most commands
+
+            switch (cmd)
+            {
+                case 0x0:   // Write command register
+                    _command = (CommandBits)value;
+                    Log.Debug(Category.Z80DMA, "Write 0x{0:x2} ({1}) to command register",
+                                                value, _command);
+                    break;
+
+                case 0x1:   // Write request bit
+                    _channels[chan].Requested = (value & 0x04) > 0;
+                    Log.Debug(Category.Z80DMA, "Channel {0} Requested is {1}", chan, _channels[chan].Requested);
+                    break;
+
+                case 0x2:   // Write single mask bit
+                    _channels[chan].Masked = (value & 0x04) > 0;
+                    Log.Debug(Category.Z80DMA, "Channel {0} Masked is {1}", chan, _channels[chan].Masked);
+                    break;
+
+                case 0x3:   // Write mode register
+                    _channels[chan].Mode = (TransferMode)((value & 0x0c) >> 2);
+                    _channels[chan].AutoInit = ((value & 0x10) != 0);
+                    _channels[chan].AddrDecrement = ((value & 0x20) != 0);
+                    _channels[chan].Select = (ChannelMode)((value & 0xc0) >> 6);
+                    Log.Debug(Category.Z80DMA, "Write 0x{0:x2} to channel {1} mode reg", value, chan);
+                    break;
+
+                case 0x4:   // Clear byte pointer flip flop
+                    _channels[chan].LowByte = true;
+                    break;
+
+                case 0x5:   // Master clear
+                    Reset();
+                    break;
+
+                case 0x7:   // Write all mask bits
+                    _channels[0].Masked = (value & 0x01) > 0;
+                    _channels[1].Masked = (value & 0x02) > 0;
+                    _channels[2].Masked = (value & 0x04) > 0;
+                    _channels[3].Masked = (value & 0x08) > 0;
+                    break;
+
+                default:
+                    Log.Warn(Category.Z80DMA, "Bad write to port 0x{0:x2} (illegal address), ignored", portAddress);
+                    // throw
+                    break;
+            }
         }
+
+        [Flags]
+        enum CommandBits
+        {
+            MemToMemEnable = 0x1,
+            Chan0AddrChange = 0x2,
+            MasterEnable = 0x4,
+            CompressedTiming = 0x8,
+            RotatingPriority = 0x10,
+            ExtendedWrite = 0x20,
+            DREQLow = 0x40,
+            DACKHigh = 0x80
+        }
+
+        protected enum TransferMode
+        {
+            Verify = 0,
+            Write = 1,
+            Read = 2,
+            Illegal = 3
+        }
+
+        protected enum ChannelMode
+        {
+            Demand = 0,
+            Single = 1,
+            Block = 2,
+            Cascade = 3
+        }
+
+        /// <summary>
+        /// Contains the internal byte count and vector response memory for a
+        /// single channel (plus some extra data for convenient grouping).
+        /// </summary>
+        protected struct ChannelRegister
+        {
+            public bool Requested;          // DREQ active
+            public bool Masked;             // Enable bit
+            public TransferMode Mode;       // Mode bits 2,3
+            public bool AutoInit;           // Mode bit 4
+            public bool AddrDecrement;      // Mode bit 5
+            public ChannelMode Select;      // Mode bits 6,7
+            public bool Terminated;         // Completed or cancelled
+            public bool LowByte;            // Flip flop for LSB/MSB for R/W
+            public ushort BaseAddress;
+            public ushort CurrentAddress;
+            public ushort WordCount;
+            public ushort CurrentCount;
+        }
+
+        byte _status;                       // State of all channel req/eop bits
+        byte _temporary;                    // Current "in flight" data byte
+        CommandBits _command;
+
+        ChannelRegister[] _channels;
 
         byte _controlBase;
         byte _channelBase;
@@ -129,29 +365,5 @@ namespace PERQemu.IO.Z80
     PDMAStart   equ 163Q    ; Force PERQ DMA cycle to fill/empty FiFos
     PDMAFlush   equ 164Q    ; Flush DMA FiFo to PERQ
     PDMADirect  equ 172Q    ; 0 = DMA from PERQ, 1 = DMA to PERQ
-
-    Command codes:
-        In all the commands that follow, a bits 2:0 specify an individual bit
-        0x00            Reset
-        0x10 - 0x17     Clear all IRR and IMR bits
-        0x18 - 0x1f     Clear all IRR and specific IMR bit (bits 2:0)
-        0x20 - 0x27     Clear all IMR bits
-        0x28 - 0x2f     Clear specific IMR bit
-        0x30 - 0x37     Set all IMR bits
-        0x38 - 0x3f     Set specific IMR bit
-        0x40 - 0x47     Clear all IRR bits
-        0x48 - 0x4f     Clear specific IRR bit
-        0x50 - 0x57     Set all IRR bits
-        0x58 - 0x5f     Set specific IRR bit
-        0x60 - 0x6f     Clear highest priority ISR bit
-        0x70 - 0x77     Clear all ISR bits
-        0x78 - 0x7f     Clear specific ISR bit
-
-        Command codes 0x80 and above require specific decoding based on varying
-        bitfield assignments:
-        0x80 - 0xaf     Load Mode register
-        0xb0 - 0xbf     Preselected IMR for subsequent loading from data bus
-        0xc0 - 0xcf     Preselected Auto Clear reg for   "      "    "    "
-        0xd0 - 0xff     Load byte count reg and select response memory level
 
  */

--- a/PERQemu/Emulator/IO/Z80/i8237DMA.cs
+++ b/PERQemu/Emulator/IO/Z80/i8237DMA.cs
@@ -278,8 +278,12 @@ namespace PERQemu.IO.Z80
                 byte save = _status;
                 Log.Info(Category.Z80DMA, "Read 0x{0:x2} from status register", save);
 
-                // Reading status clears the EOP bits (S3..S0)!
+                // Reading status clears the EOP bits (S3..S0)!  AND the TC bits!?
                 _status &= 0xf0;
+                _channels[0].Terminated = false;
+                _channels[1].Terminated = false;
+                _channels[2].Terminated = false;
+                _channels[3].Terminated = false;
                 _interruptEnabled = false;
 
                 return save;

--- a/PERQemu/Emulator/IO/Z80/i8254PIT.cs
+++ b/PERQemu/Emulator/IO/Z80/i8254PIT.cs
@@ -120,6 +120,8 @@ namespace PERQemu.IO.Z80
                 Log.Debug(Category.CTC, "Timer {0} Channel {1} initialized", _parent.Unit, Number);
             }
 
+            // in mode 3, loading the high byte of the counter starts the clock;
+            // not loading it leaves it off/suspended
             public int Number;
             public ushort Counter;
             public bool Running;
@@ -164,6 +166,11 @@ namespace PERQemu.IO.Z80
     CTC.MSB    equ 20H             ; Load MSB only
     CTC.Both   equ 30H             ; Load both LSB and MSB
 
+    EIO.doc has PIT B ports 125/126 reversed; the schematic and code above are
+    correct (Tx speed is on chan 2 for both RS232 ports).  Not sure why they
+    didn't just do one Tx/Rx speed on RS232B and devote separate channels to the
+    tablet and speech... sigh.
+    
     If 3RCC didn't define bits for Modes 2,4,5 then they probably didn't use
     them?  Each chip devotes two separate channels to the RS232 ports (separate
     Tx/Rx clocks!) and one to the second channel (keyboard, tablet/speech).  No

--- a/PERQemu/Emulator/Memory/VideoController.cs
+++ b/PERQemu/Emulator/Memory/VideoController.cs
@@ -144,7 +144,7 @@ namespace PERQemu.Memory
                     return 0x0;
 
                 default:
-                    throw new UnhandledIORequestException($"Unhandled Memory IO Read from port {ioPort:x2}");
+                    throw new UnhandledIORequestException(ioPort);
             }
         }
 
@@ -281,7 +281,7 @@ namespace PERQemu.Memory
                     break;
 
                 default:
-                    throw new UnhandledIORequestException($"Unhandled IO Write to port {ioPort:x2}, data {value:x4}");
+                    throw new UnhandledIORequestException(ioPort, value);
             }
         }
 

--- a/PERQemu/Emulator/Memory/VideoController.cs
+++ b/PERQemu/Emulator/Memory/VideoController.cs
@@ -167,7 +167,7 @@ namespace PERQemu.Memory
                     _startOver = (value & (int)StatusRegister.StartOver) != 0;
 
                     // Deal with some special cases :-|
-                    if (!_startOver && VSyncEnabled && (_lineCounterInit == 40 || _lineCounterInit == 43))                    
+                    if (VSyncEnabled && (_lineCounterInit == 40 || _lineCounterInit == 43))
                     {
                         // ** PNX 1 & 2 HACK **
                         //
@@ -185,17 +185,6 @@ namespace PERQemu.Memory
                         // See Docs/Video.txt for more information.
                         //
                         _startOver = (_scanLine > _lastVisibleScanLine);
-                    }
-
-                    if (_startOver && DisplayEnabled)
-                    {
-                        // ** PNX 2 HACK (part two) **
-                        //
-                        // Although I could hack the state machine to ignore the
-                        // _startOver bit at the end of visible bands, resetting
-                        // it here works too and keeps all the cruft in one place.
-                        //
-                        _startOver = false;
                     }
 
                     // Clear interrupt
@@ -224,14 +213,27 @@ namespace PERQemu.Memory
 
                 case 0xe3:  // Video control port
 
-                    // ** ACCENT S6 HACK **
-                    // The S6 microcode doesn't properly initialize VidNext for
-                    // "normal" display and passes in a bogus value instead; POS
-                    // does it correctly.  Argh.  Crude workaround here...
-                    if ((value & 0xff00) == 0xff00)
+                    // More special cases
+                    if ((value & 0x1f00) == 0x1f00)
                     {
-                        // Force just EnableDisplay, no cursor, map normal.
+                        // ** ACCENT S6 HACK **
+                        // The S6 microcode doesn't properly initialize VidNext for
+                        // "normal" display and passes in a bogus value instead; POS
+                        // does it correctly.  Argh.  Crude workaround here is to
+                        // force just EnableDisplay, no cursor, map normal.
                         value = 0x8400;
+                    }
+
+                    if ((value & 0x1f00) == 0 && VSyncEnabled)
+                    {
+                        // ** PNX 3 HACK **
+                        // Okay, ICL.  You ALMOST got it right: using two bands for
+                        // vertical sync (20 lines + 23 lines) and you properly set
+                        // the StartOver bit on the second one -- but you only set
+                        // VSync on the first band!  The workaround here, to keep the
+                        // state machine happy, is to force VSync back on for that
+                        // band so the final count expires and fires the interrupt.
+                        value = (int)StatusRegister.EnableVSync;
                     }
 
                     // Video Ctrl (343 W) Mode control bits (see IOVideo.pas)
@@ -263,7 +265,8 @@ namespace PERQemu.Memory
                         RunStateMachine();
                     }
 
-                    Log.Debug(Category.Display, "Video status port set to {0} @ line {1}", _videoStatus, _scanLine);
+                    Log.Debug(Category.Display, "Video status port set to {0} (0x{1:x}) @ line {2}",
+                                               _videoStatus, value, _scanLine);
                     break;
 
                 case 0xe4:  // Load cursor X position
@@ -395,7 +398,7 @@ namespace PERQemu.Memory
             // Trigger an interrupt if the line counter is set and has reached 0
             if (_lineCounter == 0 && _lineCounterInit > 0)
             {
-                if (MicroInterruptEnabled && !_lineCountOverflow)     // Just trigger it once...
+                if (MicroInterruptEnabled && !_lineCountOverflow)     // Just once...
                 {
                     Log.Debug(Category.Display, "Line counter overflow @ scanline {0}", _scanLine);
                     _system.CPU.RaiseInterrupt(InterruptSource.LineCounter);
@@ -408,7 +411,15 @@ namespace PERQemu.Memory
                 // blanking band we're about to start a new frame, so reset the
                 // scan line counter before we return to idle.  The microcode
                 // should then reenable the display at line zero!
-                if (_startOver)
+                //
+                // ** PNX 2 HACK (part two) **
+                // 
+                // PNX 2 sets the StartOver bit at the _start_ of the first band
+                // after the VSync band, which means we end up off by 128 lines.
+                // StartOver is forced on when it should be set (but isn't) and
+                // is ignored here when it is set (and shouldn't be).  Sigh.
+                // 
+                if (_startOver && !DisplayEnabled)
                 {
                     _scanLine = 0;
                 }
@@ -435,10 +446,11 @@ namespace PERQemu.Memory
         {
             UpdateSignals();
 
-            Console.WriteLine("counterInit={0}, count={1}, overflow={2}, intrEnabled={3}",
-                              _lineCounterInit, _lineCounter, _lineCountOverflow, MicroInterruptEnabled);
-            Console.WriteLine("scanline={0}, startOver={1}, state={2}, crt={3}",
-                              _scanLine, _startOver, _state, _crtSignals);
+            Console.WriteLine("counterInit={0}, count={1}, overflow={2}, scanline={3}, startOver={4}",
+                              _lineCounterInit, _lineCounter, _lineCountOverflow, _scanLine, _startOver);
+            Console.WriteLine("screen @ 0x{0:x}, cursor @ 0x{1:X}, intrEnabled={2}",
+                              _displayAddress, _cursorAddress, MicroInterruptEnabled);
+            Console.WriteLine("state={0}, crt={1}", _state, _crtSignals);
         }
 
         /// <summary>

--- a/PERQemu/Emulator/PERQSystem.cs
+++ b/PERQemu/Emulator/PERQSystem.cs
@@ -295,8 +295,8 @@ namespace PERQemu
                     break;
 
                 case RunState.ShuttingDown:
-                    _state = RunState.Off;
                     Shutdown();
+                    _state = RunState.Off;
                     break;
 
                 case RunState.Reset:
@@ -362,11 +362,10 @@ namespace PERQemu
             // Now go away or I shall taunt you some more
             _inputs.Shutdown();
             _display.Shutdown();
-
-            if (_oio != null) _oio.Shutdown();
-
+            _oio?.Shutdown();
             _iob.Shutdown();
             _cpu.Shutdown();
+
             _ioBus = null;
             Log.Detail(Category.Emulator, "PERQSystem shutdown.");
         }

--- a/PERQemu/Emulator/PERQSystem.cs
+++ b/PERQemu/Emulator/PERQSystem.cs
@@ -264,10 +264,10 @@ namespace PERQemu
                             {
                                 _cpu.Run();
                                 _iob.Run();
-                            }
-                            while (!CPU.IncrementBPC);
 
-                            _state = RunState.Paused;
+                                if (CPU.IncrementBPC) _state = RunState.Paused;
+                            }
+                            while (_state == RunState.RunInst);
                         });
                     break;
 
@@ -280,14 +280,16 @@ namespace PERQemu
                     RunGuarded(() =>
                         {
                             var startTime = _iob.Z80System.Clocks;
+
                             do
                             {
                                 _cpu.Run();
                                 _iob.Run();
-                            }
-                            while (_iob.Z80System.Clocks == startTime);
 
-                            _state = RunState.Paused;
+                                if (_iob.Z80System.Clocks != startTime)
+                                    _state = RunState.Paused;
+                            }
+                            while (_state == RunState.RunZ80Inst);
                         });
                     break;
 
@@ -395,6 +397,11 @@ namespace PERQemu
             }
         }
 
+        // Debugging
+        public void ShowThreadStatus()
+        {
+            _cpu.ShowThreadStatus();
+        }
 
         #region The white zone is for media loading and unloading only
 

--- a/PERQemu/Emulator/PERQSystem.cs
+++ b/PERQemu/Emulator/PERQSystem.cs
@@ -286,7 +286,8 @@ namespace PERQemu
                                 _cpu.Run();
                                 _iob.Run();
 
-                                if (_iob.Z80System.Clocks != startTime)
+                                if (!_iob.Z80System.IsRunning ||
+                                     _iob.Z80System.Clocks != startTime)
                                     _state = RunState.Paused;
                             }
                             while (_state == RunState.RunZ80Inst);

--- a/PERQemu/Emulator/SystemTimer.cs
+++ b/PERQemu/Emulator/SystemTimer.cs
@@ -32,7 +32,7 @@ namespace PERQemu
             _interval = ival;
             _period = (uint)(ival / (cycleTime * Conversion.NsecToMsec));
             _callback = new HRTimerElapsedCallback(OnElapsed);
-            _handle = HighResolutionTimer.Register(_interval, _callback);
+            _handle = HighResolutionTimer.Register(_interval, _callback, "System");
             _sync = new ManualResetEventSlim(false);
             _isEnabled = false;
 

--- a/PERQemu/PERQemu.csproj
+++ b/PERQemu/PERQemu.csproj
@@ -219,6 +219,7 @@
     <Compile Include="UI\Output\Page.cs" />
     <Compile Include="UI\Output\PNGFormatter.cs" />
     <Compile Include="UI\Output\TIFFFormatter.cs" />
+    <Compile Include="Emulator\IO\DiskDevices\MFMDiskController.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="COPYING.txt" />
@@ -722,6 +723,8 @@
     <None Include="Resources\printing-3.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Docs\Hardware References\EIO_Disk_Quick_Feb83.txt" />
+    <None Include="Docs\HardDisks.txt" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/PERQemu/PERQemu.csproj
+++ b/PERQemu/PERQemu.csproj
@@ -220,6 +220,7 @@
     <Compile Include="UI\Output\PNGFormatter.cs" />
     <Compile Include="UI\Output\TIFFFormatter.cs" />
     <Compile Include="Emulator\IO\DiskDevices\MFMDiskController.cs" />
+    <Compile Include="Emulator\IO\Z80\PERQDMA.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="COPYING.txt" />

--- a/PERQemu/PERQemu.csproj
+++ b/PERQemu/PERQemu.csproj
@@ -221,6 +221,7 @@
     <Compile Include="UI\Output\TIFFFormatter.cs" />
     <Compile Include="Emulator\IO\DiskDevices\MFMDiskController.cs" />
     <Compile Include="Emulator\IO\Z80\PERQDMA.cs" />
+    <Compile Include="Emulator\IO\DMARegisters.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="COPYING.txt" />

--- a/PERQemu/PROM/eioz80.lst
+++ b/PERQemu/PROM/eioz80.lst
@@ -2216,6 +2216,9 @@ ROM:0F4F Jump:
 ROM:0F4F    JP  (HL)                ; Call address specified in the message
 ROM:0F4F ; End Z80
 ROM:0FFF ; End of ROM
+RAM:4000 ;
+RAM:4000 ; Start of RAM
+RAM:4000 RAM:
 RAM:6800 ;
 RAM:6800 ; Start of Data
 RAM:6800 PERQO.Cmd      ; PERQ output port available

--- a/PERQemu/PROM/eioz80.lst
+++ b/PERQemu/PROM/eioz80.lst
@@ -1,4 +1,4 @@
-﻿ROM:0000 ;
+ROM:0000 ;
 ROM:0000 ; EIO Z80 v100.017
 ROM:0000 ; Copyright (C) 1982, 1983 Three Rivers Computer Corporation
 ROM:0000 ; Assembled/massaged for PERQemu by skeezicsb from original source
@@ -10,10 +10,10 @@ ROM:0000    DI                      ; Disable All interrupts until init done
 ROM:0001    JP  Start               ; Jump to start of initialization
 ROM:0004 ;
 ROM:0004 Version:
-ROM:0004    byte 64h                ; VerMajor
-ROM:0005    byte 11h                ; VerMinor
-ROM:0006    byte 0                  ; Checksum of ROM
-ROM:0007    byte 0                  ; Filler
+ROM:0004    .byte 64h               ; VerMajor
+ROM:0005    .byte 11h               ; VerMinor
+ROM:0006    .byte 0                 ; Checksum of ROM
+ROM:0007    .byte 0                 ; Filler
 ROM:0008 ;
 ROM:0008 ; Clock (Not present in ROM)
 ROM:0008 ClockInit:
@@ -95,38 +95,105 @@ ROM:008E    JP  EIRETI
 ROM:0091 PtrSp.ISR:
 ROM:0091    JP  EIRETI
 ROM:0094 ;
-ROM:0094 ;   0094-00C2  RSA       SECTION BYTE 
-ROM:0094 RSA:
-ROM:00C2 ;   0094-00C2  RSA       SECTION BYTE 
-ROM:00C3 ;   00C3-00F1  RSB       SECTION BYTE 
-ROM:00C3 RSB:
-ROM:00F1 ;   00C3-00F1  RSB       SECTION BYTE 
+ROM:0094 ; RS-232A task (Not present in ROM)
+ROM:0094 RSATx.ISR:
+ROM:0094 RSASt.ISR:
+ROM:0094 RSARx.ISR:
+ROM:0094 RSASP.ISR:
+ROM:0094    JP  EIRETI              ; Dummy interrupt routine
+ROM:0097 RSAInit:
+ROM:0097    XOR  A                  ; Get a zero
+ROM:0098    LD  (RSA.Flg), A        ; Clear all the flags
+ROM:009B    LD   HL, InitTab
+ROM:009E    LD   B, InitTabL        ; Table length
+ROM:00A0    LD   C, RSAControl
+ROM:00A2    OTIR
+ROM:00A4    RET
+ROM:00A5 InitTab:
+ROM:00A5    .byte  00011000B        ; Channel Reset command
+ROM:00A6    .byte         1         ; Finally register 1
+ROM:00A7    .byte  00000000B        ; Disables the interrupts
+ROM:00A7 ; InitTabL equ 3           ; Length of table
+ROM:00A8 XRSA:
+ROM:00A8    LD   HL, RSA.Flg
+ROM:00AB    SET  NAKFlgBit, (HL)    ; Set NAK pending flag
+ROM:00AD    JP   PERQEnable         ; And re-enable interrupts
+ROM:00B0 ZRSA:
+ROM:00B0    LD   C, DevRSA          ; Device code
+ROM:00B2    LD   HL, RSA.Flg        ; Check for ACK/NAK
+ROM:00B5    BIT  NAKFlgBit, (HL)
+ROM:00B7    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:00BA    RET
+ROM:00BB RSATask:
+ROM:00BB    LD   HL,RSA.Cmd
+ROM:00BE    CALL Wait               ; Wait for command
+ROM:00C1    JR   RSATask            ; Repeat
+ROM:00C2 ;
+ROM:00C2 ; End of RS-232A
+ROM:00C3 ;
+ROM:00C3 ; RS-232B task (Not present in ROM)
+ROM:00C3 RSBTx.ISR:
+ROM:00C3 RSBSt.ISR:
+ROM:00C3 RSBRx.ISR:
+ROM:00C3 RSBSP.ISR:
+ROM:00C3    JP  EIRETI              ; Dummy interrupt routine
+ROM:00C6 RSBInit:
+ROM:00C6    XOR  A                  ; Get a zero
+ROM:00C7    LD  (RSB.Flg), A        ; Clear all the flags
+ROM:00CA    LD   HL, InitTab
+ROM:00CD    LD   B, InitTabL        ; Table length
+ROM:00CF    LD   C, RSBControl
+ROM:00D1    OTIR
+ROM:00D3    RET
+ROM:00D4 ;
+ROM:00D4 ; Initialisation table for RS232
+ROM:00D4 InitTab:
+ROM:00D4    .byte  00011000B        ; Channel Reset command
+ROM:00D5    .byte         1         ; Finally register 1
+ROM:00D6    .byte  00000000B        ; Disables the interrupts
+ROM:00D6 ; InitTabL equ 3           ; Length of table
+ROM:00D7 XRSB:
+ROM:00D7    LD   HL, RSB.Flg
+ROM:00DA    SET  NAKFlgBit, (HL)    ; Set NAK pending flag
+ROM:00DC    JP   PERQEnable         ; And re-enable interrupts
+ROM:00DF ZRSB:
+ROM:00DF    LD   C, DevRSB          ; Device code
+ROM:00E1    LD   HL, RSB.Flg        ; Check for ACK/NAK
+ROM:00E4    BIT  NAKFlgBit, (HL)
+ROM:00E6    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:00E9    RET
+ROM:00EA RSBTask:
+ROM:00EA    LD   HL, RSB.Cmd
+ROM:00ED    CALL Wait               ; Wait for command
+ROM:00F0    JR   RSBTask            ; Repeat
+ROM:00F1 ;
+ROM:00F1 ; End of RS232-B
 ROM:0100 ;
 ROM:0100 ; Vectors (What goes here?)
-ROM:0110    word   020E         ; VecPDMA
-ROM:0112    word   0C81         ; VecPERQO
-ROM:0114    word   09EA         ; VecPERQI
-ROM:0116    word   0655         ; VecFloppy
-ROM:0118    word   0020         ; VecGPIB
-ROM:011A    word   01BE         ; VecZDMA
+ROM:0110    .word  020E     ; VecPDMA
+ROM:0112    .word  0C81     ; VecPERQO
+ROM:0114    .word  09EA     ; VecPERQI
+ROM:0116    .word  0655     ; VecFloppy
+ROM:0118    .word  0020     ; VecGPIB
+ROM:011A    .word  01BE     ; VecZDMA
 ROM:0120 VecRS0:
-ROM:0120    word   0C93         ; SPTx.ISR  Speech transmit buffer empty
-ROM:0122    word   0C93         ; SPSt.ISR  Speech status change
-ROM:0124    word   008E         ; PtrRx.ISR Pointer receive buffer full
-ROM:0126    word   0091         ; PtrSp.ISR Pointer special receive condition
-ROM:0128    word   0094         ; RSATx.ISR Channel A transmit buffer empty
-ROM:012A    word   0094         ; RSASt.ISR Channel A status change
-ROM:012C    word   0094         ; RSARx.ISR Channel A receive buffer full
-ROM:012E    word   0094         ; RSASp.ISR Channel A special receive condition
+ROM:0120    .word  0C93     ; SPTx.ISR  Speech transmit buffer empty
+ROM:0122    .word  0C93     ; SPSt.ISR  Speech status change
+ROM:0124    .word  008E     ; PtrRx.ISR Pointer receive buffer full
+ROM:0126    .word  0091     ; PtrSp.ISR Pointer special receive condition
+ROM:0128    .word  0094     ; RSATx.ISR Channel A transmit buffer empty
+ROM:012A    .word  0094     ; RSASt.ISR Channel A status change
+ROM:012C    .word  0094     ; RSARx.ISR Channel A receive buffer full
+ROM:012E    .word  0094     ; RSASp.ISR Channel A special receive condition
 ROM:0130 VecRS1:
-ROM:0130    word   099D         ; KBTx.ISR Keyboard transmit buffer empty
-ROM:0132    word   09B0         ; KBSt.ISR Keyboard status change
-ROM:0134    word   0972         ; KBRx.ISR Keyboard receive buffer full
-ROM:0136    word   09BB         ; KBSp.ISR Keyboard special receive condition
-ROM:0138    word   00C3         ; RSBTx.ISR Channel A transmit buffer empty
-ROM:013A    word   00C3         ; RSBSt.ISR Channel A status change
-ROM:013C    word   00C3         ; RSBRx.ISR Channel A receive buffer full
-ROM:013E    word   00C3         ; RSBSp.ISR Channel A special receive condition
+ROM:0130    .word  099D     ; KBTx.ISR Keyboard transmit buffer empty
+ROM:0132    .word  09B0     ; KBSt.ISR Keyboard status change
+ROM:0134    .word  0972     ; KBRx.ISR Keyboard receive buffer full
+ROM:0136    .word  09BB     ; KBSp.ISR Keyboard special receive condition
+ROM:0138    .word  00C3     ; RSBTx.ISR Channel A transmit buffer empty
+ROM:013A    .word  00C3     ; RSBSt.ISR Channel A status change
+ROM:013C    .word  00C3     ; RSBRx.ISR Channel A receive buffer full
+ROM:013E    .word  00C3     ; RSBSp.ISR Channel A special receive condition
 ROM:0140 EIRETI:
 ROM:0140    EI
 ROM:0141    RETI
@@ -136,21 +203,21 @@ ROM:0143 ; DMA
 ROM:0143 DMAInit:
 ROM:0143    OUT (DMAMCLR), A        ; Issue master clear
 ROM:0145    IN   A, (DMACSR)        ; Read to clear status register
-ROM:0147    LD   A, 01100000B       ; DACK active low, DREQ active LOW, Extend Writ
-ROM:0149    OUT (DMACSR), A         ; Fixed Prio, Normal timing, enable cotroller
-ROM:014B    LD   A, I.WrRes | I.By1 | I.ZDMA; 1 byte response for Z80 DMA interrupt
+ROM:0147    LD   A, 01100000B       ; DACK active L, DREQ active L, Extend Write
+ROM:0149    OUT (DMACSR), A         ; Fixed Prio, Normal timing, enable cntrller
+ROM:014B    LD   A, I.WrRes | I.By1 | I.ZDMA; 1 byte response for Z80 DMA intr
 ROM:014D    OUT (INTCSR), A         ; Enable writting response memory
 ROM:014F    LD   A, LO(VecZDMA)
 ROM:0151    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
-ROM:0153    LD   A, I.WrRes | I.By1 | I.PDMA; 1 byte response for PERQ DMA interrupt
+ROM:0153    LD   A, I.WrRes | I.By1 | I.PDMA; 1 byte response for PERQ DMA intr
 ROM:0155    OUT (INTCSR), A         ; Enable writting response memory
 ROM:0157    LD   A, LO(VecPDMA)
 ROM:0159    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
 ROM:015B    LD   A, I.CIMRIRR | I.PDMA
 ROM:015D    OUT (INTCSR), A         ; Clear IMR and IRR for PERQ DMA interrupts
 ROM:015F    XOR  A
-ROM:0160    LD  (DMA.GNBC+1), A     ; Clear flag byte for GPIB.
-ROM:0163    LD  (DMA.SNBC+1), A     ; Clear flag byte for SIO.
+ROM:0160    LD  (DMA.GNBC+1), A     ; Clear flag byte for GPIB
+ROM:0163    LD  (DMA.SNBC+1), A     ; Clear flag byte for SIO
 ROM:0166    RET
 ROM:0167 DMAtoMem:
 ROM:0167    LD   L, A               ; Save channel number
@@ -275,7 +342,7 @@ ROM:021D    LD   HL, DMA.GNBC+1     ; Otherwise, point to flag byte for GPIB
 ROM:0220    BIT  7, (HL)            ; Test if next DMA should be started
 ROM:0222    RET  Z                  ; Return if not
 ROM:0223    RES  7, (HL)            ; Clear bit
-ROM:0225    LD   BC, (DMA.GNBC)     ; Get byte count (Bit 15 = zero)
+ROM:0225    LD   BC, (DMA.GNBC)     ; Get byte count (bit 15 = zero)
 ROM:0229    LD   DE, (DMA.GNAdr)    ; Set buffer address
 ROM:022D    JP   DoDMA              ; Go make the setup call
 ROM:0230 TrySIO:
@@ -285,7 +352,7 @@ ROM:0233    LD   HL, DMA.SNBC+1     ; Otherwise, point to flag byte for SIO
 ROM:0236    BIT  7, (HL)            ; Test if next DMA should be started
 ROM:0238    RET  Z                  ; Return if not
 ROM:0239    RES  7, (HL)            ; Clear bit
-ROM:023B    LD   BC, (DMA.SNBC)     ; Get byte count (Bit 15 = zero)
+ROM:023B    LD   BC, (DMA.SNBC)     ; Get byte count (bit 15 = zero)
 ROM:023F    LD   DE, (DMA.SNAdr)    ; Set buffer address
 ROM:0243 DoDMA:
 ROM:0243 ; NB: Reg A still holds the DMA Channel number
@@ -311,7 +378,7 @@ ROM:0266    LD   HL, BufFloppy
 ROM:0269    LD  (AdrFloppy), HL     ; Address of first buffer
 ROM:026C    LD   HL, BufFloppy + BufSFloppy
 ROM:026F    LD  (AdrFloppy+2), HL   ; Address of second buffer
-ROM:0272    LD   A, I.WrRes | I.By1 | I.Floppy; 1 byte response for DMA interrupt
+ROM:0272    LD   A, I.WrRes | I.By1 | I.Floppy; 1 byte response for DMA intr
 ROM:0274    OUT (INTCSR), A         ; Enable writting response memory
 ROM:0276    LD   A, LO(VecFlopppy)  ; Get address of vector
 ROM:0278    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
@@ -339,7 +406,7 @@ ROM:02A1    BIT  ACKFlgBit, A
 ROM:02A3    JP   NZ, SendACK        ; If necessary send ACK and return
 ROM:02A6    BIT  NAKFlgBit, A
 ROM:02A8    JP   NZ, SendNAK        ; If necessary send NAK and return
-ROM:02AB    Bit  SRFlgBit, A
+ROM:02AB    BIT  SRFlgBit, A
 ROM:02AD    RET  Z                  ; Return if no status to send
 ROM:02AE    Res  SRFlgBit, (HL)     ; Reset status request pending
 ROM:02B0    LD   HL, PERQO.Cmd
@@ -926,7 +993,7 @@ ROM:0749    INC  HL
 ROM:074A    LD   A, (F.Parm3)       ; Set Head Load Time from Parameter 2
 ROM:074D    CP   128                ; Is head load time too large?
 ROM:074F    JR   NC, BadSpecify     ; Branch if Parameter too large
-ROM:0751    SLA  A                  ; Position and set to DMA move (Bit 0)
+ROM:0751    SLA  A                  ; Position and set to DMA move (bit 0)
 ROM:0753    LD  (HL), A
 ROM:0754    LD   B, 3               ; Length of command
 ROM:0756    JR   SendCommand        ; Send command to the floppy
@@ -962,7 +1029,7 @@ ROM:077E    LD   A, (HL)            ; Get current character
 ROM:077F    INC  HL
 ROM:0780    OUT (IOAFData), A       ; Write byte to controller
 ROM:0782    DJNZ SendNext           ; Branch if more to send
-ROM:0784    OR   A                  ; Clear Carry Bit
+ROM:0784    OR   A                  ; Clear Carry bit
 ROM:0785    RET
 ROM:0786 SendError:
 ROM:0786    CALL GetResult          ; Get result from floppy
@@ -1123,24 +1190,24 @@ ROM:08BE ; End Initial
 ROM:08BF ;
 ROM:08BF ; Keyboard
 ROM:08BF KBInit:
-ROM:08BF    XOR A
+ROM:08BF    XOR  A
 ROM:08C0    LD  (KBIBuff), A        ; Clear PUT offset of the buffer
 ROM:08C3    LD  (KBIBuff+1), A      ; Clear GET offset of the buffer
-ROM:08C6    LD  HL, KB.Flg          ; Address of flag byte
+ROM:08C6    LD   HL, KB.Flg         ; Address of flag byte
 ROM:08C9    LD  (HL), A             ; Clear flag byte
-ROM:08CA    SET EnbFlgBit,(HL)      ; Enable the keyboard
-ROM:08CC    LD  A, CTC.KBSel | CTC.Both | CTC.M3
+ROM:08CA    SET  EnbFlgBit, (HL)    ; Enable the keyboard
+ROM:08CC    LD   A, CTC.KBSel | CTC.Both | CTC.M3
 ROM:08CE    OUT (CTCB.CSR), A       ; Select counter and mode
-ROM:08D0    LD  A, LO(833)          ; = 4Mhz / (300Baud * 16) = 833
+ROM:08D0    LD   A, LO(833)         ; = 4Mhz / (300Baud * 16) = 833
 ROM:08D2    OUT (CTC.KB), A
-ROM:08D4    LD  A, HI(833)          ; High byte of 833
+ROM:08D4    LD   A, HI(833)         ; High byte of 833
 ROM:08D6    OUT (CTC.KB), A
-ROM:08D8    IN  A,(KBData)          ; Clear any pending character
-ROM:08DA    IN  A,(KBData)          ; Clear any pending character
-ROM:08DC    IN  A,(KBData)          ; Clear any pending character
-ROM:08DE    LD  HL, InitTab         ; Address of initialization 
-ROM:08E1    LD  B, InitTabL         ; Total writes
-ROM:08E3    LD  C, KBControl        ; I/O Address of keyboard control
+ROM:08D8    IN   A, (KBData)        ; Clear any pending character
+ROM:08DA    IN   A, (KBData)        ; Clear any pending character
+ROM:08DC    IN   A, (KBData)        ; Clear any pending character
+ROM:08DE    LD   HL, InitTab        ; Address of initialization 
+ROM:08E1    LD   B, InitTabL        ; Total writes
+ROM:08E3    LD   C, KBControl       ; I/O Address of keyboard control
 ROM:08E5    OTIR
 ROM:08E7    RET
 ROM:08E8 ;
@@ -1150,9 +1217,9 @@ ROM:08E8    .byte  00011000B        ; Channel Reset command
 ROM:08E9    .byte          4        ; Select register 4
 ROM:08EA    .byte  01001000B        ; *16 clock, 1 1/2 stop, no parity
 ROM:08EB    .byte          3        ; Select Register 3
-ROM:08EC    .byte  11100001B        ; 8 Bits, Auto Enable, Rx Enable
+ROM:08EC    .byte  11100001B        ; 8 bits, Auto Enable, Rx Enable
 ROM:08ED    .byte          5        ; Select Register 5
-ROM:08EE    .byte  11100000B        ; DTR, 8 Bits, disable Tx
+ROM:08EE    .byte  11100000B        ; DTR, 8 bits, disable Tx
 ROM:08EF    .byte          1        ; Select register 1
 ROM:08F0    .byte  00011100B        ; Enables reciever interrupts
 ROM:08F1    .byte          2        ; Select Register 2
@@ -1172,7 +1239,7 @@ ROM:0904    JR   NZ, NAKIt          ; Branch if invalid command
 ROM:0906    CALL KBINIT
 ROM:0909    JR   ACKIt
 ROM:090B KBSense:
-ROM:090B    SET  SRFlgBit,(HL)      ; Set the status request bit
+ROM:090B    SET  SRFlgBit, (HL)     ; Set the status request bit
 ROM:090D    JP   PERQEnable
 ROM:0910 KBConfig:
 ROM:0910    LD   A, (PERQIBuff+3)       ; The On/Off byte
@@ -1268,21 +1335,21 @@ ROM:09AD    EI
 ROM:09AE    RETI
 ROM:09B0 KBSt.ISR:
 ROM:09B0    EXX
-ROM:09B1    EX  AF, AF
-ROM:09B2    LD  A, RSRExtInt        ; Reset external interrupt
+ROM:09B1    EX   AF, AF
+ROM:09B2    LD   A, RSRExtInt       ; Reset external interrupt
 ROM:09B4    OUT (KBControl), A
 ROM:09B6    EXX
-ROM:09B7    EX  AF, AF
+ROM:09B7    EX   AF, AF
 ROM:09B8    EI
 ROM:09B9    RETI
 ROM:09BB KBSp.ISR:
 ROM:09BB    EXX
-ROM:09BC    EX  AF, AF
-ROM:09BD    LD  A, RSRError         ; Error reset
+ROM:09BC    EX   AF, AF
+ROM:09BD    LD   A, RSRError        ; Error reset
 ROM:09BF    OUT (KBControl), A
-ROM:09C1    IN  A, (KBData)         ; Discard the char
+ROM:09C1    IN   A, (KBData)        ; Discard the char
 ROM:09C3    EXX
-ROM:09C4    EX  AF, AF
+ROM:09C4    EX   AF, AF
 ROM:09C5    EI
 ROM:09C6    RETI
 ROM:09C7 ;
@@ -1373,7 +1440,7 @@ ROM:0A54    JR   CountOK
 ROM:0A56 ExaminePacket:
 ROM:0A56    LD  A, (PERQIBuff+1)    ; Get device number
 ROM:0A59    CP  DevFloppy           ; Is device floppy?
-ROM:0A5B    JP  Z, XFloppy          ; Yes, have floppy module handle new command
+ROM:0A5B    JP  Z, XFloppy          ; Yes, have Floppy module handle new command
 ROM:0A5E    CP  DevRSA              ; Is device RSA?
 ROM:0A60    JP  Z, XRSA             ; Yes, have RSA module handle new command
 ROM:0A63    CP  DevRSB              ; Is device RSB?
@@ -1604,7 +1671,7 @@ ROM:0C0A    OUT (PDMADirect), A     ; Set to write to the PERQ
 ROM:0C0C    OUT (PDMAFlush), A      ; Flush FIFOs (Data does not matter)
 ROM:0C0E    LD   A, D.PERQ          ; DMA Device is PERQ
 ROM:0C10    DI
-ROM:0C11    CALL DMAtoDEV           ; Setup to DMA using BC and DE
+ROM:0C11    CALL DMAtoDev           ; Setup to DMA using BC and DE
 ROM:0C14    EI
 ROM:0C15    LD   HL, DMAPERQ
 ROM:0C18    CALL Wait               ; Wait for DMA to finish
@@ -1678,14 +1745,46 @@ ROM:0C88    EX   AF, AF
 ROM:0C89    EI
 ROM:0C8A    RETI
 ROM:0C8C FIFOWait:
-ROM:0C8C    IN  A, (PERQ.Sts)       ; Get PERQ status
-ROM:0C8E    BIT 7, A                ; Test FIFO to PERQ full
-ROM:0C90    RET NZ                  ; Return if not full
-ROM:0C91    JR  FIFOWait            ; Go wait again
+ROM:0C8C    IN   A, (PERQ.Sts)      ; Get PERQ status
+ROM:0C8E    BIT  7, A               ; Test FIFO to PERQ full
+ROM:0C90    RET  NZ                 ; Return if not full
+ROM:0C91    JR   FIFOWait           ; Go wait again
 ROM:0C92 ;
 ROM:0C92 ; End PERQ
 ROM:0C93 ;
-ROM:0C93 ; Speech
+ROM:0C93 ; Speech task (Not present in ROM)
+ROM:0C93 SPTx.ISR:
+ROM:0C93 SPSp.ISR:
+ROM:0C93 SPSt.ISR:
+ROM:0C93    JP  EIRETI
+ROM:0C96 SPInit:
+ROM:0C96    XOR  A
+ROM:0C97    LD  (Speech.Flg), A     ; Clear the flag
+ROM:0C9A    LD   HL, InitTab        ; Initialization table
+ROM:0C9D    LD   B, InitTabL        ; Length of table
+ROM:0C9F    LD   C, SPControl       ; Initialise Channel B of SIO
+ROM:0CA1    OTIR
+ROM:0CA3    RET
+ROM:0CA4 InitTab:
+ROM:0CA4    .byte  00011000B        ; Reset Channel
+ROM:0CA5    .byte          1
+ROM:0CA6    .byte  00000000B        ; Disable all interrupts
+ROM:0CA6 ; InitTabL equ 3           ; Length of table
+ROM:0CA7 XSpeech:
+ROM:0CA7    LD   HL, Speech.Flg
+ROM:0CAA    SET  NAKFlgBit, (HL)    ; Cue low volume to send NAK
+ROM:0CAC    JP   PERQEnable         ; Enable PERQ and return
+ROM:0CAF ZSpeech:
+ROM:0CAF    LD   C, DevSpeech       ; Device code
+ROM:0CB1    LD   HL, Speech.Flg     ; Check Speech for ACK/NAK
+ROM:0CB4    BIT  NAKFlgBit, (HL)
+ROM:0CB6    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:0CB9    RET
+ROM:0CBA SPTask:
+ROM:0CBA    LD   HL, Speech.Cmd
+ROM:0CBD    CALL Wait               ; Wait for command
+ROM:0CC0    JR   SPTask             ; Go look for another command
+ROM:0CC1 ;
 ROM:0CC1 ; End Speech
 ROM:0CC2 ;
 ROM:0CC2 ; Task Control
@@ -1758,7 +1857,7 @@ ROM:0D34    LD   A, TskRun
 ROM:0D36    LD  (DE), A             ; Wake it up
 ROM:0D37    INC (HL)                ; Counting upwards towards zero
 ROM:0D38    JR   Z, SDone
-ROM:0D3A SIGNext:
+ROM:0D3A SigNext:
 ROM:0D3A    DJNZ SigLoop            ; Any more candidates?
 ROM:0D3C SDone:
 ROM:0D3C    POP  IX                 ; Restore IX for caller
@@ -1928,24 +2027,24 @@ ROM:0E1A    RET  Z                  ; In case he said zero bytes?
 ROM:0E1B    INC  HL                 ; Point at the GET value
 ROM:0E1C BlGetLoop:
 ROM:0E1C    PUSH BC                 ; Remember the count
-ROM:0E1D    LD   C,(HL)             ; Pick up GET value
-ROM:0E1E    LD   B,0                ; Extend to 16 bits
+ROM:0E1D    LD   C, (HL)            ; Pick up GET value
+ROM:0E1E    LD   B, 0               ; Extend to 16 bits
 ROM:0E20    INC  C                  ; Bump the GET counter
 ROM:0E21    PUSH HL                 ; Save our buffer pointer
 ROM:0E22    ADD  HL,BC              ; And add GET into the buffer pointer
-ROM:0E23    LD   A,(HL)             ; Pick up the char
-ROM:0E24    LD  (DE),A              ; and store it off
+ROM:0E23    LD   A, (HL)            ; Pick up the char
+ROM:0E24    LD  (DE), A             ; and store it off
 ROM:0E25    POP  HL                 ; Get back buffer pointer
 ROM:0E26    LD   A, C               ; Pick up incremented GET
 ROM:0E27    AND  MaxBuff            ; Wrap it around
-ROM:0E29    LD  (HL),A              ; and store it back
+ROM:0E29    LD  (HL), A             ; and store it back
 ROM:0E2A    INC  DE                 ; Crank up the destination pointer
 ROM:0E2B    POP  BC                 ; Fetch back the counter
 ROM:0E2C    DJNZ BlGetLoop          ; And decrement
 ROM:0E2E    RET
 ROM:0E2F BlockHide:
 ROM:0E2F    DI
-ROM:0E30    LD   C,(HL)             ; Pick up current PUT
+ROM:0E30    LD   C, (HL)            ; Pick up current PUT
 ROM:0E31 HideLp:
 ROM:0E31    PUSH BC                 ; Hide count
 ROM:0E32    LD   A, (DE)
@@ -2097,8 +2196,8 @@ ROM:0F23    LD   HL, Z80.Cmd        ; Point to command flag
 ROM:0F26    LD   A, DevZ80          ; Device to source data
 ROM:0F28    CALL NZ, GetBlkData     ; If non-zero length Get the data
 ROM:0F2B    JP   NC, Z80ACK         ; ACK and get next command if no error
-ROM:0F2E ;  We end up here if GetBlkData failed, i.e., we did not get a BlkData cmd
-ROM:0F2E ;  from PERQ. Instead, we got a new cmd for Z80 - go handle it
+ROM:0F2E ; We end up here if GetBlkData failed, i.e., we did not get a BlkData
+ROM:0F2E ; cmd from PERQ.  Instead, we got a new cmd for Z80 - go handle it
 ROM:0F2E    LD   HL, Z80.Flg
 ROM:0F31    LD   C, DevZ80
 ROM:0F33    CALL SendNAK            ; Force NAK

--- a/PERQemu/PROM/eioz80.lst
+++ b/PERQemu/PROM/eioz80.lst
@@ -1,4 +1,2225 @@
-﻿ROM:0000 ; Placeholder until listing can be generated!
+﻿ROM:0000 ;
+ROM:0000 ; EIO Z80 v100.017
+ROM:0000 ; Copyright (C) 1982, 1983 Three Rivers Computer Corporation
+ROM:0000 ; Assembled/massaged for PERQemu by skeezicsb from original source
+ROM:0000 ; Rebuilt and verified with zasm online Fri Apr  5 04:32:56 PDT 2024
+ROM:0000 ;
+ROM:0000 ; Hardware Start location  (0)
+ROM:0000 Loc0:
+ROM:0000    DI                      ; Disable All interrupts until init done
+ROM:0001    JP  Start               ; Jump to start of initialization
+ROM:0004 ;
+ROM:0004 Version:
+ROM:0004    byte 64h                ; VerMajor
+ROM:0005    byte 11h                ; VerMinor
+ROM:0006    byte 0                  ; Checksum of ROM
+ROM:0007    byte 0                  ; Filler
+ROM:0008 ;
+ROM:0008 ; Clock (Not present in ROM)
+ROM:0008 ClockInit:
+ROM:0008    XOR A
+ROM:0009    LD  (Clock.Flg), A      ; Clear clock flag byte
+ROM:000C    RET
+ROM:000D XClock:
+ROM:000D    LD  HL, Clock.Flg       ; Point at flag byte
+ROM:0010    SET NAKFlgBit, (HL)     ; All others get NAKed
+ROM:0012    JP  PERQEnable          ; Re-enable PERQ input and return
+ROM:0015 ZClock:
+ROM:0015    LD  C, DevClock         ; Device code
+ROM:0017    LD  HL, Clock.Flg       ; Check Clock for NAK
+ROM:001A    BIT NAKFlgBit, (HL)
+ROM:001C    JP  NZ, SendNAK         ; If necessary send NAK and return
+ROM:001F    RET
+ROM:0020 ;
+ROM:0020 ; GPIB (Not present in ROM)
+ROM:0020 GPIB.ISR:
+ROM:0020    JP   EIRETI             ; Dummy interrupt routine
+ROM:0023 GPIBInit:
+ROM:0023    XOR  A                  ; Get a zero
+ROM:0024    LD  (GPIB.Flg), A       ; Clear all the flags
+ROM:0027    OUT (GPIMsk0), A        ; Disable all interrupts
+ROM:0029    OUT (GPControl), A      ; Setup as Not system controller
+ROM:002B    RET
+ROM:002C XGPIB:
+ROM:002C    LD   HL, GPIB.Flg
+ROM:002F    SET  NAKFlgBit, (HL)    ; Set NAK pending flag
+ROM:0031    JP   PERQEnable         ; And re-enable interrupts
+ROM:0034 ZGPIB:
+ROM:0034    LD   C, DevGPIB         ; Device code
+ROM:0036    LD   HL, GPIB.Flg       ; Check for NAK
+ROM:0039    BIT  NAKFlgBit, (HL)
+ROM:003B    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:003E    RET
+ROM:003F GPIBTask:
+ROM:003F    LD   HL, GPIB.Cmd
+ROM:0042    CALL Wait               ; Wait for command
+ROM:0045    JR   GPIBTask           ; Repeat
+ROM:0047 ;
+ROM:0047 ; Low Volume task
+ROM:0047 LVTask:
+ROM:0047    CALL ZGPIB              ; Check for GPIB activity
+ROM:004A    CALL ZRSA               ; Check for RS232A activity
+ROM:004D    CALL ZRSB               ; Check for RS232B activity
+ROM:0050    CALL ZSpeech            ; Check for Speech activity
+ROM:0053    CALL ZZ80               ; Check for Z80 activity
+ROM:0056    CALL CPUGive            ; Relinquish CPU for task
+ROM:0059    CALL ZGPIB              ; Check for GPIB activity again
+ROM:005C    CALL ZPointer           ; Check for Pointer activity
+ROM:005F    CALL ZFloppy            ; Check for Floppy activity
+ROM:0062    CALL ZKB                ; Check for Keyboard activity
+ROM:0065    CALL ZClock             ; Check for Clock activity       
+ROM:0068    CALL CPUGive            ; Relinquish CPU for task
+ROM:006B    JP   LVTask             ; Start check again
+ROM:006E ;
+ROM:006E ; Pointer task (Not present in ROM)
+ROM:006E PointInit:
+ROM:006E    XOR  A
+ROM:006F    LD  (Kriz.Flg), A       ; Turn it off
+ROM:0072    LD   A, RSWR3
+ROM:0074    OUT (SPControl), A      ; Select write register 3
+ROM:0076    LD   A, 00000000B
+ROM:0078    OUT (SPControl), A      ; Receiver disabled
+ROM:007A    RET                     ; Thats all just now
+ROM:007B XPointer:
+ROM:007B    LD  HL, Kriz.Flg        ; Point to flag byte
+ROM:007E    SET NAKFlgBit, (HL)
+ROM:0080    JP  PERQEnable
+ROM:0083 ZPointer:
+ROM:0083    LD  HL, Kriz.Flg        ; Check Pointer for ACK/NAK
+ROM:0086    LD  C, DevPointer       ; Setup device number
+ROM:0088    BIT NAKFlgBit, (HL)
+ROM:008A    JP  NZ, SendNAK         ; If necessary send NAK and return
+ROM:008D    RET
+ROM:008E PtrRx.ISR:
+ROM:008E    JP  EIRETI
+ROM:0091 PtrSp.ISR:
+ROM:0091    JP  EIRETI
+ROM:0094 ;
+ROM:0094 ;   0094-00C2  RSA       SECTION BYTE 
+ROM:0094 RSA:
+ROM:00C2 ;   0094-00C2  RSA       SECTION BYTE 
+ROM:00C3 ;   00C3-00F1  RSB       SECTION BYTE 
+ROM:00C3 RSB:
+ROM:00F1 ;   00C3-00F1  RSB       SECTION BYTE 
+ROM:0100 ;
+ROM:0100 ; Vectors (What goes here?)
+ROM:0110    word   020E         ; VecPDMA
+ROM:0112    word   0C81         ; VecPERQO
+ROM:0114    word   09EA         ; VecPERQI
+ROM:0116    word   0655         ; VecFloppy
+ROM:0118    word   0020         ; VecGPIB
+ROM:011A    word   01BE         ; VecZDMA
+ROM:0120 VecRS0:
+ROM:0120    word   0C93         ; SPTx.ISR  Speech transmit buffer empty
+ROM:0122    word   0C93         ; SPSt.ISR  Speech status change
+ROM:0124    word   008E         ; PtrRx.ISR Pointer receive buffer full
+ROM:0126    word   0091         ; PtrSp.ISR Pointer special receive condition
+ROM:0128    word   0094         ; RSATx.ISR Channel A transmit buffer empty
+ROM:012A    word   0094         ; RSASt.ISR Channel A status change
+ROM:012C    word   0094         ; RSARx.ISR Channel A receive buffer full
+ROM:012E    word   0094         ; RSASp.ISR Channel A special receive condition
+ROM:0130 VecRS1:
+ROM:0130    word   099D         ; KBTx.ISR Keyboard transmit buffer empty
+ROM:0132    word   09B0         ; KBSt.ISR Keyboard status change
+ROM:0134    word   0972         ; KBRx.ISR Keyboard receive buffer full
+ROM:0136    word   09BB         ; KBSp.ISR Keyboard special receive condition
+ROM:0138    word   00C3         ; RSBTx.ISR Channel A transmit buffer empty
+ROM:013A    word   00C3         ; RSBSt.ISR Channel A status change
+ROM:013C    word   00C3         ; RSBRx.ISR Channel A receive buffer full
+ROM:013E    word   00C3         ; RSBSp.ISR Channel A special receive condition
+ROM:0140 EIRETI:
+ROM:0140    EI
+ROM:0141    RETI
+ROM:0142 ; End Vectors
+ROM:0143 ;
+ROM:0143 ; DMA
+ROM:0143 DMAInit:
+ROM:0143    OUT (DMAMCLR), A        ; Issue master clear
+ROM:0145    IN   A, (DMACSR)        ; Read to clear status register
+ROM:0147    LD   A, 01100000B       ; DACK active low, DREQ active LOW, Extend Writ
+ROM:0149    OUT (DMACSR), A         ; Fixed Prio, Normal timing, enable cotroller
+ROM:014B    LD   A, I.WrRes | I.By1 | I.ZDMA; 1 byte response for Z80 DMA interrupt
+ROM:014D    OUT (INTCSR), A         ; Enable writting response memory
+ROM:014F    LD   A, LO(VecZDMA)
+ROM:0151    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
+ROM:0153    LD   A, I.WrRes | I.By1 | I.PDMA; 1 byte response for PERQ DMA interrupt
+ROM:0155    OUT (INTCSR), A         ; Enable writting response memory
+ROM:0157    LD   A, LO(VecPDMA)
+ROM:0159    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
+ROM:015B    LD   A, I.CIMRIRR | I.PDMA
+ROM:015D    OUT (INTCSR), A         ; Clear IMR and IRR for PERQ DMA interrupts
+ROM:015F    XOR  A
+ROM:0160    LD  (DMA.GNBC+1), A     ; Clear flag byte for GPIB.
+ROM:0163    LD  (DMA.SNBC+1), A     ; Clear flag byte for SIO.
+ROM:0166    RET
+ROM:0167 DMAtoMem:
+ROM:0167    LD   L, A               ; Save channel number
+ROM:0168    DEC  BC                 ; DMA expects count -1
+ROM:0169    LD   H, C               ; Save
+ROM:016A    SLA  A                  ; * 2
+ROM:016C    ADD  A, DMAADR0         ; Bias by channel 0 I/O address
+ROM:016E    LD   C, A               ; Point to device
+ROM:016F    OUT (DMAPOINT), A       ; Clear pointer
+ROM:0171    OUT (C), E              ; Output low address
+ROM:0173    OUT (C), D              ; Output high address
+ROM:0175    INC  C                  ; Point to Word count I/O Address
+ROM:0176    OUT (DMAPOINT), A       ; Clear pointer
+ROM:0178    OUT (C), H              ; Send low byte count
+ROM:017A    OUT (C), B              ; Send high byte count
+ROM:017C    LD   A, D.Write | D.Incr| D.Single ; Write to memory
+ROM:017E    OR   L                  ; OR in channel number
+ROM:017F    OUT (DMAMODE), A        ; Set mode increment single byte read transfer
+ROM:0181    LD   A, L               ; Get channel number
+ROM:0182    OR   D.Clear            ; Clear mask bit
+ROM:0184    OUT (DMAMASK), A        ; Enable DMA transfer
+ROM:0186    LD   C, H               ; Copy back low byte of BC
+ROM:0187    INC  BC                 ; Restore byte count
+ROM:0188    RET
+ROM:0189 DMAtoDev:
+ROM:0189    LD   L, A               ; Save channel number
+ROM:018A    DEC  BC                 ; DMA expects count -1
+ROM:018B    LD   H, C               ; Save
+ROM:018C    SLA  A                  ; * 2
+ROM:018E    ADD  A, DMAADR0         ; Bias by channel 0 I/O address
+ROM:0190    LD   C, A               ; Point to device
+ROM:0191    OUT (DMAPOINT), A       ; Clear pointer
+ROM:0193    OUT (C), E              ; Output low address
+ROM:0195    OUT (C), D              ; Output high address
+ROM:0197    INC  C                  ; Point to Word count I/O Address
+ROM:0198    OUT (DMAPOINT), A       ; Clear pointer
+ROM:019A    OUT (C), H              ; Send low byte count
+ROM:019C    OUT (C), B              ; Send high byte count
+ROM:019E    LD   A, D.Read | D.Incr| D.Single ; Read from memory
+ROM:01A0    OR   L                  ; OR in channel number
+ROM:01A1    OUT (DMAMODE), A        ; Set mode increment single byte write transfer
+ROM:01A3    LD   A, L               ; Get channel number
+ROM:01A4    OR   D.Clear            ; Clear mask bit
+ROM:01A6    OUT (DMAMASK), A        ; Enable DMA transfer
+ROM:01A8    LD   C, H               ; Copy back low byte of BC
+ROM:01A9    INC  BC                 ; Restore byte count
+ROM:01AA    RET
+ROM:01AB DMAStop:
+ROM:01AB    LD   H, A               ; Save channel number
+ROM:01AC    CALL DMAStatus
+ROM:01AF    LD   A, B               ; Test for zero byte count
+ROM:01B0    OR   C                  ; Add high byte
+ROM:01B1    JR   Z, DMAStopX        ; Exit if already at Zero
+ROM:01B3    LD   C, H               ; Get channel number back
+ROM:01B4    LD   B, 0
+ROM:01B6    LD   HL, DMADone        ; Address of channel 0 semaphore
+ROM:01B9    ADD  HL, BC             ; Offset by channel number
+ROM:01BA    CALL Signal             ; Signal
+ROM:01BD DMAStopX:
+ROM:01BD    RET
+ROM:01BE ZDMA.ISR:
+ROM:01BE    EXX
+ROM:01BF    EX   AF, AF
+ROM:01C0    IN   A, (DMACSR)        ; Read the status register
+ROM:01C2    PUSH AF                 ; Save for later
+ROM:01C3    BIT  D.GPIB, A          ; GPIB DMA done?
+ROM:01C5    JR   Z, Ch1X            ; Branch if not complete
+ROM:01C7    Ld   A, D.GPIB          ; Load channel number
+ROM:01C9    CALL DMANext            ; Try to start next DMA command
+ROM:01CC    LD   HL, DMAGPIB
+ROM:01CF    CALL Signal             ; Signal end of DMA transfer
+ROM:01D2 Ch1X:
+ROM:01D2    POP  AF                 ; Get back the status register
+ROM:01D3    PUSH AF                 ; Save it again
+ROM:01D4    BIT  D.SIO, A           ; SIO DMA done?
+ROM:01D6    JR   Z, Ch2X            ; Branch if not complete
+ROM:01D8    LD   A, D.SIO           ; Load channel number
+ROM:01DA    CALL DMANext            ; Try to start next DMA command
+ROM:01DD    LD   HL, DMASIO
+ROM:01E0    CALL Signal             ; Signal end of DMA transfer
+ROM:01E3 Ch2X:
+ROM:01E3    POP  AF                 ; Get back the status register
+ROM:01E4    BIT  D.PERQ, A          ; PERQ DMA done?
+ROM:01E6    JR   Z, Ch3X            ; Branch if not complete
+ROM:01E8    LD   HL, DMAPERQ
+ROM:01EB    CALL Signal             ; Signal end of DMA transfer
+ROM:01EE Ch3X:
+ROM:01EE    EXX
+ROM:01EF    EX   AF, AF
+ROM:01F0    EI
+ROM:01F1    RETI
+ROM:01F3 DMAStatus:
+ROM:01F3    OR   D.Set              ; Add bit to mask the channel
+ROM:01F5    OUT (DMAMASK), A        ; Disable the DMA channel
+ROM:01F7    AND !D.Set              ; Remove added bit
+ROM:01F9    SLA  A                  ; * 2
+ROM:01FB    Add  A, DMAADR0         ; Bias by DMA channel 0 I/O address
+ROM:01FD    LD   C, A               ; Set I/O Address
+ROM:01FE    OUT (DMAPOINT), A       ; Reset internal even/odd byte pointer
+ROM:0200    IN   E, (C)             ; Get low address
+ROM:0202    IN   D, (C)             ; Get high address
+ROM:0204    INC  C                  ; Bump to Word Count I/O Address
+ROM:0205    OUT (DMAPOINT), A       ; Reset internal even/odd byte pointer
+ROM:0207    IN   A, (C)             ; Get low byte count
+ROM:0209    IN   B, (C)             ; Get high byte count
+ROM:020B    LD   C, A               ; Set low byte count
+ROM:020C    INC  BC                 ; Adjust to true remaining byte count
+ROM:020D    RET
+ROM:020E PDMA.ISR:
+ROM:020E    EXX
+ROM:020F    EX   AF, AF
+ROM:0210    LD   A, I.PDMA | I.Single | I.SIMR
+ROM:0212    OUT (INTCSR), A         ; Disable further interrupts
+ROM:0214    EXX
+ROM:0215    EX   AF, AF
+ROM:0216    EI
+ROM:0217    RETI
+ROM:0219 DMANext:
+ROM:0219    CP   D.GPIB             ; Is the GPIB channel being selected?
+ROM:021B    JR   NZ, TrySIO         ; If not, see if it is the SIO
+ROM:021D    LD   HL, DMA.GNBC+1     ; Otherwise, point to flag byte for GPIB
+ROM:0220    BIT  7, (HL)            ; Test if next DMA should be started
+ROM:0222    RET  Z                  ; Return if not
+ROM:0223    RES  7, (HL)            ; Clear bit
+ROM:0225    LD   BC, (DMA.GNBC)     ; Get byte count (Bit 15 = zero)
+ROM:0229    LD   DE, (DMA.GNAdr)    ; Set buffer address
+ROM:022D    JP   DoDMA              ; Go make the setup call
+ROM:0230 TrySIO:
+ROM:0230    CP   D.SIO              ; Is the SIO channel being selected?
+ROM:0232    RET  NZ                 ; If not, exit
+ROM:0233    LD   HL, DMA.SNBC+1     ; Otherwise, point to flag byte for SIO
+ROM:0236    BIT  7, (HL)            ; Test if next DMA should be started
+ROM:0238    RET  Z                  ; Return if not
+ROM:0239    RES  7, (HL)            ; Clear bit
+ROM:023B    LD   BC, (DMA.SNBC)     ; Get byte count (Bit 15 = zero)
+ROM:023F    LD   DE, (DMA.SNAdr)    ; Set buffer address
+ROM:0243 DoDMA:
+ROM:0243 ; NB: Reg A still holds the DMA Channel number
+ROM:0243    BIT  6, B               ; To or From memory?
+ROM:0245    JP   Z, DMAtoDev        ; Branch if should DMA to device
+ROM:0248    RES  6, B               ; Clear it
+ROM:024A    JP   DMAtoMEM           ; Branch if should DMA to memory
+ROM:024C ;
+ROM:024C ; End DMA
+ROM:024D ;
+ROM:024D ; Floppy
+ROM:024D FloppyInit:
+ROM:024D    LD   A, 0
+ROM:024F    LD  (Floppy.Rdy), A     ; Initialize i/o semaphore
+ROM:0252    LD  (Floppy.Flg), A     ; Clear the flag byte
+ROM:0255    LD  (Flop.Ratn), A      ; Clear attention pending flag
+ROM:0258    LD  (F.Command), A      ; Clear current command
+ROM:025B    LD  (F.Status), A       ; Set No status present
+ROM:025E    LD   A, FC_Idle         ; Force to Idle
+ROM:0260    LD  (F.CmdBuf), A
+ROM:0263    CALL GetResult          ; Remove any pending status from controller
+ROM:0266    LD   HL, BufFloppy
+ROM:0269    LD  (AdrFloppy), HL     ; Address of first buffer
+ROM:026C    LD   HL, BufFloppy + BufSFloppy
+ROM:026F    LD  (AdrFloppy+2), HL   ; Address of second buffer
+ROM:0272    LD   A, I.WrRes | I.By1 | I.Floppy; 1 byte response for DMA interrupt
+ROM:0274    OUT (INTCSR), A         ; Enable writting response memory
+ROM:0276    LD   A, LO(VecFlopppy)  ; Get address of vector
+ROM:0278    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
+ROM:027A    RET
+ROM:027B XFloppy:
+ROM:027B    LD   A, (PI.Command)    ; Get command byte
+ROM:027E    CP   CmdSense           ; Is it a sense command?
+ROM:0280    LD   HL, Floppy.Cmd     ; Semaphore for floppy task
+ROM:0283    JP   NZ, Signal         ; If sense Signal to floppy task and return
+ROM:0286    LD   HL, Floppy.Flg     ; Address of floppy flag byte
+ROM:0289    SET  SRFlgBit, (HL)     ; Set status pending flag
+ROM:028B    JP   PERQEnable         ; Re-enable PERQ input and return
+ROM:028E ZFloppy:
+ROM:028E    LD   C, DevFloppy       ; Device code
+ROM:0290    XOR  A
+ROM:0291    LD   HL, Flop.Ratn      ; Address of Attention mask
+ROM:0294    CP  (HL)                ; Attention to be sent?
+ROM:0295    CALL NZ, SendAttn       ; Send Attention and return
+ROM:0298    LD   HL, Floppy.Flg     ; Check Floppy for ACK/NAK/status
+ROM:029B    LD   A, (HL)
+ROM:029C    AND  RespMask           ; Any responses pending?
+ROM:029E    RET  Z                  ; Return if no response pending
+ROM:029F    LD   C, DevFloppy       ; Device code
+ROM:02A1    BIT  ACKFlgBit, A
+ROM:02A3    JP   NZ, SendACK        ; If necessary send ACK and return
+ROM:02A6    BIT  NAKFlgBit, A
+ROM:02A8    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:02AB    Bit  SRFlgBit, A
+ROM:02AD    RET  Z                  ; Return if no status to send
+ROM:02AE    Res  SRFlgBit, (HL)     ; Reset status request pending
+ROM:02B0    LD   HL, PERQO.Cmd
+ROM:02B3    CALL Wait               ; Wait for output port to be free
+ROM:02B6    LD   A, 10              ; Floppy status message is 10 bytes
+ROM:02B8    LD  (PERQOBuff), A      ; Length of status
+ROM:02BB    LD   A, DevFloppy
+ROM:02BD    LD  (PERQOBuff+1), A    ; Insert the device code
+ROM:02C0    LD   A, CmdStatus
+ROM:02C2    LD  (PERQOBuff+2), A    ; Set command field to status
+ROM:02C5    LD   BC, 8              ; Set up the count
+ROM:02C8    LD   HL, F.Status       ; Floppy results area
+ROM:02CB    LD   DE, PERQOBuff+3    ; Points to data area in buffer
+ROM:02CE    LDIR                    ; Copy it across
+ROM:02D0    JP   SendPERQ           ; Send message, release port and return
+ROM:02D3 FloppyTask:
+ROM:02D3    LD   A, 26              ; Default highest sector on track
+ROM:02D5    LD  (F.EOT), A
+ROM:02D8    LD   A, 7               ; Single density gap length
+ROM:02DA    LD  (F.GPL), A
+ROM:02DD    LD   A, 0               ; sector length encoded = 0 (128 bytes)
+ROM:02DF    LD  (F.DTL), A
+ROM:02E2    LD   A, 00000000B       ; Set options MT = 0, MF = Single, SK = 0
+ROM:02E4    LD  (F.Options), A
+ROM:02E7    LD   HL, F.Command      ; Point to command buffer
+ROM:02EA    LD  (HL), CmdSpecify    ; Force specify command
+ROM:02EC    INC  HL
+ROM:02ED    LD  (HL), 3             ; Default Step Rate in milliseconds
+ROM:02EF    INC  HL
+ROM:02F0    LD  (HL), 15            ; Head unload time in 16 millisecond units
+ROM:02F2    INC  HL
+ROM:02F3    LD  (HL), 36            ; Head load time in 2 millsecond units
+ROM:02F5    CALL FloppyIO           ; Send the defaults to the controller
+ROM:02F8    JP   C, CmdWait         ; Must not be disc in drive
+ROM:02FB    LD   HL, F.Command      ; Point to command buffer
+ROM:02FE    LD  (HL), CmdRecal      ; Force recalibate
+ROM:0300    INC  HL
+ROM:0301    XOR  A                  ; Zero
+ROM:0302    LD  (HL), A             ; Clear the unit number 
+ROM:0303    LD  (F.Cyl), A          ; Clear stored cylinder number
+ROM:0306    CALL FloppyIO           ; Execute the Recal
+ROM:0309    JP   C, CmdWait         ; Must not be disc in drive
+ROM:030C    LD   HL, Floppy.Rdy
+ROM:030F    CALL Wait               ; Wait for Recal to finish
+ROM:0312 CmdWait:
+ROM:0312    LD   HL, Floppy.Cmd     ; Address of command semaphore
+ROM:0315    CALL Wait               ; Wait for a command
+ROM:0318 RetryCmd:
+ROM:0318    LD   DE, F.Command      ; Address command area
+ROM:031B    LD   HL, PI.Command     ; Address of PERQ input command area
+ROM:031E    LD   BC, 6              ; Move command and 5 parameters
+ROM:0321    LDIR                    ; Copy command to DCB
+ROM:0323    CALL PERQEnable         ; Re-enable PERQ input port interrupts
+ROM:0326    LD   HL, F.Command      ; Get address of command
+ROM:0329    LD   A, (HL)            ; Get command value
+ROM:032A    INC  HL                 ; Point to parameter 1
+ROM:032B    CALL CmdDispatch        ; Call dispatch, returns from command
+ROM:032E    JR   CmdWait            ; Start a new command
+ROM:0330 CmdDispatch:
+ROM:0330    CP  CmdSeek             ; Seek command?
+ROM:0332    JP  Z, DO_Seek
+ROM:0335    CP  CmdRead             ; Read command?
+ROM:0337    JP  Z, DO_Rd
+ROM:033A    CP  CmdWrite            ; Write command?
+ROM:033C    JP  Z, DO_Wr
+ROM:033F    CP  CmdRecal            ; Recalibrate
+ROM:0341    JP  Z, DO_Recal
+ROM:0344    CP  CmdSnsDrive         ; Sense device status command?
+ROM:0346    JP  Z, DO_SDrive
+ROM:0349    CP  CmdSpecify          ; Specify command?
+ROM:034B    JP  Z, DO_Specify
+ROM:034E    CP  CmdFormat           ; Format command?
+ROM:0350    JP  Z, DO_Format
+ROM:0353    CP  CmdConfig           ; Configure Command?
+ROM:0355    JP  Z, DO_Config
+ROM:0358    CP  CmdRdID             ; Read Id command?
+ROM:035A    JP  Z, DO_RdID
+ROM:035D    CP  CmdRdDel            ; Read deleted data command?
+ROM:035F    JP  Z, DO_RdDel
+ROM:0362    CP  CmdWrDel            ; Write Deleted data?
+ROM:0364    JP  Z, DO_WrDel
+ROM:0367    CP  CmdBoot             ; Boot command?
+ROM:0369    JP  Z, DO_Boot
+ROM:036C    CP  CmdReset            ; Reset Command?
+ROM:036E    JP  Z, DO_Reset         ; Fall into NAKFinish
+ROM:0371 NAKFinish:
+ROM:0371    LD  HL, Floppy.Flg      ; Address of floppy flag byte
+ROM:0374    LD  C, DevFloppy
+ROM:0376    JP  SendNAK             ; Send NAK for command, and return
+ROM:0379 ACKFinish:
+ROM:0379    LD  HL, Floppy.Flg      ; Address of floppy flag byte
+ROM:037C    LD  C, DevFloppy
+ROM:037E    JP  SendACK             ; Send ACK for command, and return
+ROM:0381 CmdAbort:
+ROM:0381    LD  HL, Floppy.Flg      ; Point to flag byte
+ROM:0384    SET NAKFlgBit, (HL)     ; Cue Low Volume to do NAK
+ROM:0386    POP HL                  ; Clean up stack
+ROM:0387    JP  RetryCmd            ; Go process the new cmd
+ROM:038A SetAddr:
+ROM:038A    INC HL                  ; Point to Parm2
+ROM:038B    LD  A, (HL)             ; Save sector starting number
+ROM:038C    LD  (F.Sector), A
+ROM:038F    INC HL                  ; Point to F.Parm3
+ROM:0390    LD  C, (HL)             ; Get low byte of byte count
+ROM:0391    INC HL                  ; Point to F.Parm4
+ROM:0392    LD  B, (HL)             ; Get high byte of byte cont
+ROM:0393    LD  (F.ByteCnt), BC     ; Set initial byte count
+ROM:0397    RET
+ROM:0398 SetSize:
+ROM:0398    LD  A, (F.DTL)          ; Get data length
+ROM:039B    LD  BC, 128             ; Assume size is 128 bytes / sector
+ROM:039E    OR  A                   ; Test for zero
+ROM:039F    JR  Z, SetMin           ; Return if size = 128
+ROM:03A1    LD  BC, 256             ; use size = 256
+ROM:03A4    DEC A                   ; Decrement size
+ROM:03A5    JR  Z, SetMin           ; Return if size = 256
+ROM:03A7    LD  BC, 512             ; Set size = 512
+ROM:03AA    DEC A                   ; Decrement size
+ROM:03AB    JR  Z, SetMin           ; Return if size = 512
+ROM:03AD    LD  BC, 1024            ; Set size = 1024
+ROM:03B0    DEC A                   ; Decrement size
+ROM:03B1    JR  Z, SetMin           ; Return if size = 1024
+ROM:03B3    LD  BC, 128             ; Use default size
+ROM:03B6 SetMin:
+ROM:03B6    LD  HL, (F.ByteCnt)     ; Get remaining byte count
+ROM:03B9    OR  A                   ; Clear carry bit
+ROM:03BA    SBC HL, BC              ; Subtract sector size from remaining
+ROM:03BC    RET NC                  ; Return if enough for sector
+ROM:03BD    ADD HL, BC              ; Restore remaining byte
+ROM:03BE    LD  B, H                ; Copy count remaining
+ROM:03BF    LD  C, L
+ROM:03C0    XOR A                   ; Clear A
+ROM:03C1    LD  L, A                ; Clear Low byte of remaining count
+ROM:03C2    LD  H, A                ; Clear High byte of remaining count
+ROM:03C3    RET
+ROM:03C4 CheckStatus:
+ROM:03C4    LD  HL, F.Status        ; Address of status buffer
+ROM:03C7    LD  A, (HL)             ; Get current status type
+ROM:03C8    OR  A                   ; Check if no status
+ROM:03C9    SCF                     ; Force error
+ROM:03CA    RET Z                   ; Return error if no status present
+ROM:03CB    CP  2                   ; Check if only device status
+ROM:03CD    SCF                     ; Force error
+ROM:03CE    RET Z                   ; Return if drive status
+ROM:03CF    INC HL                  ; Point to Status register 0
+ROM:03D0    LD  A, (HL)             ; Get first status byte
+ROM:03D1    AND 0C0H                ; Retain only bits 7 and 6
+ROM:03D3    RET Z                   ; Return with carry = 0 if no error
+ROM:03D4    SCF                     ; Set error flag
+ROM:03D5    RET
+ROM:03D6 DO_Config:
+ROM:03D6    LD  B, (HL)             ; Get Highest sector number from parameter 1
+ROM:03D7    INC HL
+ROM:03D8    LD  C, (HL)             ; Get Gap Length from parameter 2
+ROM:03D9    INC HL
+ROM:03DA    LD  A, (HL)             ; Get Data Length from parameter 3
+ROM:03DB    INC HL
+ROM:03DC    CP  2                   ; Is it too large?
+ROM:03DE    JR  NC, NAKFinish       ; Branch if invalid config
+ROM:03E0    LD  (F.DTL), A          ; Save data length
+ROM:03E3    LD  A, (HL)             ; Get option bits
+ROM:03E4    AND 0E0H                ; Retain only MT, MF, SK
+ROM:03E6    LD  (F.Options), A      ; Save option bits
+ROM:03E9    LD  HL, F.EOT           ; Address of end of track
+ROM:03EC    LD  (HL), B             ; Set Highest sector number
+ROM:03ED    LD  HL, F.GPL           ; Address of gap length
+ROM:03F0    LD  (HL), C             ; Set Gap Length
+ROM:03F1    JR  ACKFinish           ; Get new command
+ROM:03F3 DO_Rd:
+ROM:03F3 DO_RdDel:
+ROM:03F3    CALL SetAddr            ; Set address and transfer request size
+ROM:03F6    LD   A, C               ; Copy low byte count address
+ROM:03F7    OR   B                  ; Or in high byte
+ROM:03F8    JP   Z, ACKFinish       ; Branch to done if zero length transfer
+ROM:03FB    CALL StartRead          ; Start read of sector into Buffer A
+ROM:03FE    JR   C, ReadError       ; Take exit if error
+ROM:0400 ReadLoop:
+ROM:0400    LD   DE, (AdrFloppy)    ; Get first buffer address
+ROM:0404    LD   HL, (AdrFloppy+2)  ; Get other buffer address
+ROM:0407    LD  (AdrFloppy), HL     ; Set first to other
+ROM:040A    LD  (AdrFloppy+2), DE   ; Set other to first
+ROM:040E    LD   HL, Floppy.Rdy     ; Address of I/O completion
+ROM:0411    CALL Wait               ; Wait for Floppy completion
+ROM:0414    CALL CheckStatus        ; Check status of transfer
+ROM:0417    JR   C, ReadError       ; Error on read
+ROM:0419    LD   HL, F.Sector       ; Address of current sector number
+ROM:041C    INC (HL)                ; Update sector number
+ROM:041D    CALL SetSize            ; Set size to read in BC
+ROM:0420    PUSH BC                 ; Save byte count
+ROM:0421    LD  (F.ByteCnt), HL     ; Set remaining byte count
+ROM:0424    LD   A, L               ; Copy low remaining count
+ROM:0425    OR   H                  ; Or high remaining count to check for zero
+ROM:0426    CALL NZ, StartRead      ; If more then Start read of another sector
+ROM:0429    POP  BC                 ; Restore byte count
+ROM:042A    JR   C, ReadError       ; Jump if error or read
+ROM:042C    LD   HL, Floppy.Cmd     ; Address of command flag
+ROM:042F    LD   DE, (AdrFloppy+2)  ; Address of buffer just read
+ROM:0433    LD   A, DevFloppy       ; Device code
+ROM:0435    CALL SendBlkData        ; CALL routine to send block data to PERQ
+ROM:0438    JP   C, CmdAbort        ; Abort if error in sending
+ROM:043B    LD   HL, (F.ByteCnt)    ; Get address of remaining byte count
+ROM:043E    LD   A, H               ; Get low byte of length
+ROM:043F    OR   L                  ; Or High byte of length
+ROM:0440    JR   NZ, ReadLoop       ; If any left to read then repeat
+ROM:0442 ReadDone:
+ROM:0442    JP  ACKFinish           ; Send ACK and start new command
+ROM:0445 ReadError:
+ROM:0445    JP  NAKFinish           ; Send NAK and start new command
+ROM:0448 StartRead:
+ROM:0448    CALL SetSize            ; Load BC with byte count
+ROM:044B    LD   DE, (AdrFloppy)    ; Start with first buffer
+ROM:044F    LD   A, D.Floppy        ; Address of floppy
+ROM:0451    DI
+ROM:0452    CALL DMAtoMem           ; Setup DMA Channel for single sector transfer
+ROM:0455    EI
+ROM:0456    JP   FloppyIO           ; Do command setup and start transfer command
+ROM:0459 DO_Wr:
+ROM:0459 DO_WrDel:
+ROM:0459    CALL SetAddr            ; Set address and transfer request size
+ROM:045C    LD   A, C               ; Copy low byte count address
+ROM:045D    OR   B                  ; Or in high byte
+ROM:045E    JP   Z, ACKFinish       ; Branch to done if zero length transfer
+ROM:0461    CALL GetBlk             ; Setup for and call GetBlkData
+ROM:0464    JR   C, WrBlk1Err       ; Branch if can not get block data
+ROM:0466 WrLoop:
+ROM:0466    LD   A, B               ; Test BC = 0
+ROM:0467    OR   C
+ROM:0468    JR   Z, WRExit          ; Branch if no more data
+ROM:046A    LD   DE, (AdrFloppy)    ; Get first buffer address
+ROM:046E    LD   HL, (AdrFloppy+2)  ; Get other buffer address
+ROM:0471    LD  (AdrFloppy), HL     ; Set first to other
+ROM:0474    LD  (AdrFloppy+2), DE   ; Set other to first
+ROM:0478    PUSH BC                 ; Save byte count
+ROM:0479    CALL StartWr            ; Setup and start write to floppy
+ROM:047C    POP  BC                 ; Restore BC
+ROM:047D    JR   C, WrError         ; Take error exit
+ROM:047F    LD   HL, F.Sector       ; Address of current sector number
+ROM:0482    INC (HL)                ; Update sector number
+ROM:0483    LD   HL, (F.ByteCnt)    ; Get current byte count
+ROM:0486    OR   A                  ; Clear Carry bit
+ROM:0487    SBC  HL, BC             ; Subtract this chunk
+ROM:0489    LD  (F.ByteCnt), HL     ; Put remaining size back
+ROM:048C    LD   A, H               ; Check HL = 0
+ROM:048D    OR   L
+ROM:048E    CALL NZ, GetBlk         ; If HL <> 0 then get new block of data
+ROM:0491    JR   C, WRBlkNErr       ; Branch if error getting data
+ROM:0493    PUSH BC                 ; Save the byte count
+ROM:0494    LD   HL, Floppy.Rdy     ; Floppy io semaphore
+ROM:0497    CALL Wait               ; Wait for I/O to complete
+ROM:049A    CALL CheckStatus        ; See if Write was ok
+ROM:049D    POP  BC                 ; Restore byte count
+ROM:049E    JR   C, WRError         ; Branch if error on write
+ROM:04A0    LD   HL, (F.ByteCnt)    ; Get address of remaining byte count
+ROM:04A3    LD   A, H               ; Get low byte of length
+ROM:04A4    OR   L                  ; Or High byte of length
+ROM:04A5    JR   NZ, WrLoop         ; If any left to read to back and repeat
+ROM:04A7 WrExit:
+ROM:04A7    JP   ACKFinish          ; Send ACK and await next command
+ROM:04AA WrBlkNErr:
+ROM:04AA    LD   HL, Floppy.Rdy     ; Floppy I/O Semaphore
+ROM:04AD    CALL Wait               ; Wait for I/O to complete
+ROM:04B0 WrBlk1Err:
+ROM:04B0    JP   CmdAbort           ; Abort the write cmd
+ROM:04B3 WrError:
+ROM:04B3    JP   NAKFinish          ; Send NAK and await next command
+ROM:04B6 GetBlk:
+ROM:04B6    CALL SetSize            ; Set BC with bytes in sector to request
+ROM:04B9    LD   DE, (AdrFloppy)    ; Address of buffer
+ROM:04BD    LD   A, DevFloppy       ; Device code
+ROM:04BF    LD   HL, Floppy.Cmd     ; Floppy command semaphore address
+ROM:04C2    JP   GetBlkData         ; CALL routine to send block data to PERQ
+ROM:04C5 StartWr:
+ROM:04C5    LD   DE, (AdrFloppy+2)  ; Start with first buffer
+ROM:04C9    LD   A, D.Floppy        ; Address of floppy
+ROM:04CB    DI
+ROM:04CC    CALL DMAtoDev           ; Setup DMA Channel for single sector transfer
+ROM:04CF    EI
+ROM:04D0    JP   FloppyIO           ; Start the write
+ROM:04D3 DO_Seek:
+ROM:04D3    LD   A, (F.Parm2)       ; Get desired cylinder number
+ROM:04D6    JR   DO_SkRecal         ; Join Seek
+ROM:04D8 DO_Recal:
+ROM:04D8    XOR  A                  ; Recalibrate is to cylinder 0
+ROM:04D9 DO_SkRec:
+ROM:04D9    LD  (F.Cyl), A          ; Store in cylinder
+ROM:04DC    CALL FloppyIO           ; Execute Seek or Recal
+ROM:04DF    JP   C, NAKFinish       ; If error Send NAK and start next command
+ROM:04E2    LD   HL, Floppy.Rdy
+ROM:04E5    CALL Wait               ; Wait for I/O to complete
+ROM:04E8    CALL CheckStatus        ; See if it worked
+ROM:04EB    JP   C, NAKFinish       ; If error Send NAK and start next command
+ROM:04EE    JP   ACKFinish          ; Send ACK and do next command
+ROM:04F1 DO_Specify:
+ROM:04F1    CALL FloppyIO           ; Execute specify
+ROM:04F4    JP   C, NAKFinish       ; If error Send NAK and start next command
+ROM:04F7    JP   ACKFinish          ; Send ACK and do next command
+ROM:04FA DO_SDrive:
+ROM:04FA    CALL FloppyIO           ; Start Sense Drive command
+ROM:04FD    JP   C, NAKFinish       ; Return NAK
+ROM:0500    LD   HL, Floppy.Flg
+ROM:0503    SET  SRFlgBit, (HL)     ; Request low volume to send status
+ROM:0505    RET                     ; Return to next command
+ROM:0506 DO_RdId:
+ROM:0506    CALL FloppyIO           ; Start Read Id command
+ROM:0509    JP   C, NAKFinish       ; Return NAK
+ROM:050C    LD   HL, Floppy.Rdy
+ROM:050F    CALL Wait               ; Wait for I/O to complete
+ROM:0512    LD   HL, Floppy.Flg
+ROM:0515    SET  SRFlgBit, (HL)     ; Request low volume to send status
+ROM:0517    RET                     ; Return to next command
+ROM:0518 DO_Format:
+ROM:0518    LD   B, 0               ; Clear high byte
+ROM:051A    LD   HL, F.Parm2        ; Point to parameter 
+ROM:051D    LD   C, (HL)            ; Number of sectors per track
+ROM:051E    SLA  C                  ; Bytes in table is 4 * sectors 
+ROM:0520    SLA  C
+ROM:0522    LD   DE, (AdrFloppy)    ; Address of buffer
+ROM:0526    LD   A, DevFloppy       ; Device code
+ROM:0528    LD   HL, Floppy.Cmd     ; Floppy command semaphore address
+ROM:052B    CALL GetBlkData         ; Call routine to get block data from PERQ
+ROM:052E    JP   C, CmdAbort        ; Branch if no block data
+ROM:0531    LD   DE, (AdrFloppy)    ; Start with first buffer
+ROM:0535    LD   A, D.Floppy        ; Address of floppy
+ROM:0537    DI
+ROM:0538    CALL DMAtoDev           ; Setup DMA Channel for transfer
+ROM:053B    EI
+ROM:053C    CALL FloppyIO           ; Now start the format
+ROM:053F    LD   HL, Floppy.Rdy
+ROM:0542    CALL Wait               ; Wait until format of track complete
+ROM:0545    CALL CheckStatus        ; See it it worked
+ROM:0548    JR   C, FmtErr          ; Branch if format error
+ROM:054A    JP   ACKFinish          ; Send ACK and await new command
+ROM:054D FmtErr:
+ROM:054D    JP   NAKFinish          ; Send NAK and await new command
+ROM:0550 DO_Reset:
+ROM:0550    LD   A, 0
+ROM:0552    LD  (Floppy.Rdy), A     ; Initialize I/O semaphore
+ROM:0555    LD  (Floppy.Flg), A     ; Clear the flag byte
+ROM:0558    LD  (Flop.Ratn), A      ; Clear attention pending flag
+ROM:055B    LD  (F.Command), A      ; Clear current command
+ROM:055E    LD  (F.Status), A       ; Set No status present
+ROM:0561    LD   A, FC_Idle         ; Force to Idle
+ROM:0563    LD  (F.CmdBuf), A
+ROM:0566    CALL GetResult          ; Read any pending status from controller
+ROM:0569    JP   ACKFinish          ; Send an ACK
+ROM:056C DO_Boot:
+ROM:056C    LD   A, 26              ; Default highest sector on track
+ROM:056E    LD  (F.EOT), A
+ROM:0571    LD   A, 7               ; Single density gap length
+ROM:0573    LD  (F.GPL), A
+ROM:0576    LD   A, 0               ; Sector length encoded = 0 (128 bytes)
+ROM:0578    LD  (F.DTL), A
+ROM:057B    LD   A, 00000000B       ; Set options MT = 0, MF = Single, SK = 0
+ROM:057D    LD  (F.Options), A
+ROM:0580    LD   HL, F.Command      ; Point to command buffer
+ROM:0583    LD  (HL), CmdSpecify    ; Force specify command
+ROM:0585    INC  HL
+ROM:0586    LD  (HL), 3             ; Default Step Rate in milliseconds
+ROM:0588    INC  HL
+ROM:0589    LD  (HL), 15            ; Head unload time in 16 millisecond units
+ROM:058B    INC  HL
+ROM:058C    LD  (HL), 36            ; Head load time in 2 millsecond units
+ROM:058E    CALL FloppyIO           ; Send the defaults to the controller
+ROM:0591    JP   C, NAKFinish       ; Must not be disc in drive
+ROM:0594    LD   HL, F.Command      ; Point to command buffer
+ROM:0597    LD  (HL), CmdRecal      ; Force recalibate
+ROM:0599    INC  HL
+ROM:059A    XOR  A                  ; Zero
+ROM:059B    LD  (HL), A             ; Clear the unit number 
+ROM:059C    LD  (F.Cyl), A          ; Clear stored cylinder number
+ROM:059F    CALL FloppyIO           ; Execute the Recal
+ROM:05A2    JP   C, NAKFinish       ; Must not be disc in drive
+ROM:05A5    LD   HL, Floppy.Rdy
+ROM:05A8    CALL Wait               ; Wait for Recalibrate to finish
+ROM:05AB    LD   A, 1
+ROM:05AD    LD  (F.Sector), A       ; Set sector = 1
+ROM:05B0    LD  (F.Cyl), A          ; Start in cylinder 1
+ROM:05B3    XOR  A                  ; Zero
+ROM:05B4    LD  (F.Parm1), A        ; Set Unit select to zero, head = 0
+ROM:05B7    CALL BootRead           ; Start read of sector into Buffer A
+ROM:05BA    JR   C, BootError       ; Take error exit
+ROM:05BC    LD   HL, Floppy.Rdy     ; Address of I/O completion
+ROM:05BF    CALL Wait               ; Wait for Floppy completion
+ROM:05C2    CALL CheckStatus        ; Check status of transfer
+ROM:05C5    JR   C, BootError       ; Error on read
+ROM:05C7    LD   HL, (AdrFloppy)    ; Get address of buffer just read
+ROM:05CA    LD   A, (HL)            ; Get first byte
+ROM:05CB    CP   055H               ; Is 1st byte correct for boot sector?
+ROM:05CD    JR   NZ, BootError      ; Branch if not correct
+ROM:05CF    INC  HL
+ROM:05D0    LD   A, (HL)
+ROM:05D1    CP   0AAH               ; Is 2nd byte correct?
+ROM:05D3    JR   NZ, BootError      ; Error, return NAK
+ROM:05D5    CALL BootIncSec         ; Increment sector/head/cylinder
+ROM:05D8    CALL BootRead           ; Start read of sector into Buffer A
+ROM:05DB    JR   C, BootError       ; Take error exit
+ROM:05DD BootLoop:
+ROM:05DD    LD   DE, (AdrFloppy)    ; Get first buffer address
+ROM:05E1    LD   HL, (AdrFloppy+2)  ; Get other buffer address
+ROM:05E4    LD  (AdrFloppy), HL     ; Set first to other
+ROM:05E7    LD  (AdrFloppy+2), DE   ; Set other to first
+ROM:05EB    LD   HL, Floppy.Rdy     ; Address of I/O completion
+ROM:05EE    CALL Wait               ; Wait for Floppy completion
+ROM:05F1    CALL CheckStatus        ; Check status of transfer
+ROM:05F4    JR   C, BootError       ; Error on read
+ROM:05F6    CALL BootIncSec         ; Increment sector/head/cylinder
+ROM:05F9    CALL BootRead           ; If more then Start read of another sector
+ROM:05FC    JR   C, BootError       ; Branch if not started correct
+ROM:05FE    LD   HL, Floppy.Cmd     ; Address of command flag
+ROM:0601    LD   BC, 128            ; Size of sector
+ROM:0604    LD   DE, (AdrFloppy+2)  ; Address of  buffer
+ROM:0608    LD   A, DevFloppy       ; Device code
+ROM:060A    CALL SendBootData       ; Call routine to send block data to PERQ
+ROM:060D    JR   BootLoop           ; Get data just read
+ROM:060F BootError:
+ROM:060F    JP   NAKFinish          ; Send NAK and EXIT
+ROM:0612 BootRead:
+ROM:0612    LD   A, (F.Sector)      ; Address of current sector
+ROM:0615    CP   1                  ; Is it 1st sector of cylindar?
+ROM:0617    JR   NZ, BootNoSeek     ; No, just read
+ROM:0619    LD   A, (F.Parm1)       ; Get command options
+ROM:061C    BIT  2, A               ; Is this head 0?
+ROM:061E    JR   NZ, BootNoSeek     ; No, just read
+ROM:0620    LD   HL, F.Command      ; Point to command area
+ROM:0623    LD  (HL), CmdSeek       ; Set command to seek
+ROM:0625    CALL FloppyIO           ; Start seek
+ROM:0628    RET  C                  ; Return if error
+ROM:0629    LD   HL, Floppy.Rdy     ; Address of Floppy I/O semaphore
+ROM:062C    CALL Wait               ; Wait for seek to complete
+ROM:062F BootNoSeek:
+ROM:062F    LD   BC, 128            ; Get size of boot sectors
+ROM:0632    LD   DE, (AdrFloppy)    ; Start with first buffer
+ROM:0636    LD   A, D.Floppy        ; Address of floppy
+ROM:0638    DI
+ROM:0639    CALL DMAtoMem           ; Setup DMA Channel for single sector transfer
+ROM:063C    EI
+ROM:063D    LD   HL, F.Command      ; Point to command area
+ROM:0640    LD  (HL), CmdRead       ; Set to read command
+ROM:0642    JP   FloppyIO           ; Do command setup and start transfer command
+ROM:0645 BootIncSec:
+ROM:0645    LD   HL, F.Sector       ; Address of current sector number
+ROM:0648    INC (HL)                ; Increment to next sector
+ROM:0649    LD   A, (F.EOT)         ; Get highest sector on track
+ROM:064C    CP  (HL)                ; Compare current with highest
+ROM:064D    RET  NC                 ; Return if not end of track
+ROM:064E    LD  (HL), 1             ; Restart at first sector
+ROM:0650    LD   HL, F.Cyl          ; Get cylinder number
+ROM:0653    INC (HL)                ; Increment cylinder
+ROM:0654    RET                     ; Return all incremented
+ROM:0655 Floppy.ISR:
+ROM:0655    EXX
+ROM:0656    EX   AF, AF
+ROM:0657    LD   HL, F.CmdBuf       ; Get command buffer address
+ROM:065A    LD   A, (HL)            ; Get command
+ROM:065B    AND  FC_Mask            ; Retain only the command
+ROM:065D    JR   Z, IH_Idle         ; Branch if idle
+ROM:065F    CP   FC_Seek            ; Was it Seek?
+ROM:0661    JR   Z, IH_SenseI       ; Branch if sense interrupt required
+ROM:0663    CP   FC_Recal           ; Was it recalibrate?
+ROM:0665    JR   NZ, IH_Result      ; Branch if neither
+ROM:0667 IH_SenseI:
+ROM:0667    LD  (HL), FC_Sint       ; Change command to Sense interrupt status
+ROM:0669    LD   B, 1               ; Length of command
+ROM:066B    CALL SendCommand        ; Send command to the floppy
+ROM:066E IH_Result:
+ROM:066E    CALL GetResult          ; Get result status from controller
+ROM:0671 IH_Signal:
+ROM:0671    LD   HL, Floppy.Rdy     ; Address of IO complete semaphore
+ROM:0674    CALL Signal             ; Release task
+ROM:0677    LD   A, FC_Idle         ; Force to Idle
+ROM:0679    LD  (F.CmdBuf), A
+ROM:067C    JR   IH_Exit            ; Exit
+ROM:067D IH_Idle:
+ROM:067E    LD  (HL), FC_Sint       ; Change to sense interrupt status
+ROM:0680    LD   B, 1
+ROM:0682    CALL SendCommand        ; Send command to the floppy
+ROM:0685    LD   A, FC_Idle
+ROM:0687    LD  (F.CmdBuf), A       ; Force to Idle
+ROM:068A    CALL GetResult          ; Get the result bytes
+ROM:068D    LD   HL, Flop.Ratn      ; Address of attention flag
+ROM:0690    SET  0, (HL)            ; Set attention reason
+ROM:0692 IH_Exit:
+ROM:0692    EXX
+ROM:0693    EX  AF, AF
+ROM:0694    EI
+ROM:0695    RETI
+ROM:0697 FloppyIO:
+ROM:0697    LD  HL, F.CmdBuf        ; Address of command buffer
+ROM:069A    LD  A, (F.Command)      ; Get command byte
+ROM:069D    CP  CmdRead
+ROM:069F    JR  Z, OP_Rd            ; Branch if Read  command
+ROM:06A1    CP  CmdWrite
+ROM:06A3    JR  Z, OP_Wr            ; Branch if Write command
+ROM:06A5    CP  CmdSeek
+ROM:06A7    JP  Z, OP_Seek          ; Branch if Seek command
+ROM:06AA    CP  CmdRecal
+ROM:06AC    JP  Z, OP_Recal         ; Branch if Recalibrate
+ROM:06AF    CP  CmdRdDel
+ROM:06B1    JR  Z, OP_RdDel         ; Branch if Read Deleted
+ROM:06B3    CP  CmdWrDel
+ROM:06B5    JR  Z, OP_WrDel         ; Branch if Write Deleted
+ROM:06B7    CP  CmdRdId
+ROM:06B9    JP  Z, OP_RdId          ; Branch if Read id
+ROM:06BC    CP  CmdSpecify
+ROM:06BE    JP  Z, OP_Specify       ; Branch if Specify command
+ROM:06C1    CP  CmdFormat
+ROM:06C3    JP  Z, OP_Format        ; Branch if Format command
+ROM:06C6    CP  CmdSnsDrive
+ROM:06C8    JP  Z, OP_SnsDrive      ; Branch if Sense Drive Status 
+ROM:06CB    SCF                     ; Error on FloppyIO
+ROM:06CC    RET                     ; Return
+ROM:06CD OP_Rd:
+ROM:06CD    LD  B, FC_Rd            ; Command to Read floppy
+ROM:06CF    JR  OP_Xfer             ; Continue with transfer
+ROM:06D1 OP_RdDel:
+ROM:06D1    LD  B, FC_RdDel         ; Command to Read Deleted
+ROM:06D3    JR  OP_Xfer             ; Continue with transfer
+ROM:06D5 OP_Wr:
+ROM:06D5    LD  B, FC_Wr            ; Command to Write data
+ROM:06D7    JR  OP_Xfer             ; Continue with transfer
+ROM:06D9 OP_WrDel:
+ROM:06D9    LD  B, FC_WrDel         ; Command to Write Deleted data
+ROM:06DB    JR  OP_Xfer             ; Continue with transfer
+ROM:06DD OP_Xfer:
+ROM:06DD    CALL InsCmdOpt          ; Insert command and options
+ROM:06E0    CALL InsAddr            ; Insert address and params
+ROM:06E3    LD   B, 9               ; Length of command
+ROM:06E5    JP   SendCommand        ; Send command to floppy
+ROM:06E8 OP_RdId:
+ROM:06E8    LD   B, FC_RdId         ; Command to Read Id
+ROM:06EA    CALL InsCmdOpt          ; Insert command and options
+ROM:06ED    LD   B, 2               ; Length of command
+ROM:06EF    JP   SendCommand        ; Send command to the floppy
+ROM:06F2 OP_Format:
+ROM:06F2    LD   B, FC_Fmt          ; Command to format floppy
+ROM:06F4    CALL InsCmdOpt          ; Insert command and options
+ROM:06F7    LD   A, (F.DTL)         ; Set data length (Bytes per sector)
+ROM:06FA    LD  (HL), A
+ROM:06FB    INC  HL
+ROM:06FC    LD   A, (F.Parm2)       ; Set sector/track from parameter 2
+ROM:06FF    LD  (HL), A
+ROM:0700    INC  HL
+ROM:0701    LD   A, (F.Parm4)       ; Set gap length
+ROM:0704    LD  (HL), A
+ROM:0705    INC  HL
+ROM:0706    LD   A, (F.Parm3)       ; Set filler byte from parameter 3
+ROM:0709    LD  (HL), A
+ROM:070A    LD   B, 6               ; Number of bytes in command
+ROM:070C    JP   SendCommand        ; Send command to the floppy
+ROM:070F OP_Recal:
+ROM:070F    LD  (HL), FC_Recal      ; Command to recalibrate the floppy
+ROM:0710    INC  HL
+ROM:0712    LD   A, (F.Parm1)       ; Set options from Parameter 1
+ROM:0715    LD  (HL), A
+ROM:0716    LD   B, 2
+ROM:0718    JP   SendCommand        ; Send command to the floppy
+ROM:071B OP_SnsDrive:
+ROM:071B    LD  (HL), FC_SDrive     ; Command to sense drive status
+ROM:071D    INC  HL
+ROM:071E    LD   A, (F.Parm1)       ; Set command options
+ROM:0721    LD  (HL), A
+ROM:0722    LD   B, 2               ; Length of command
+ROM:0724    CALL SendCommand        ; Send command to the floppy
+ROM:0727    RET  C                  ; Return if error sending command to floppy
+ROM:0728    JP   GetResult          ; Get result from controller and return
+ROM:072B OP_Specify:
+ROM:072B    LD  (HL), FC_Specify    ; Command to specify new options
+ROM:072D    INC  HL
+ROM:072E    LD   A, (F.Parm1)       ; Set STP and HUT from Parameter 1
+ROM:0731    CP   16                 ; Compare with highest + 1 valid
+ROM:0733    JR   NC, BadSpecify     ; Branch if parameter is GEQ 16
+ROM:0735    NEG                     ; Arg for controller is - step rate
+ROM:0737    SLA  A                  ; Shift 4 bits to position in high nibble
+ROM:0739    SLA  A
+ROM:073B    SLA  A
+ROM:073D    SLA  A
+ROM:073F    LD   B, A               ; Save until head unload time ready
+ROM:0740    LD   A, (F.Parm2)       ; Get head unload time
+ROM:0743    CP   16                 ; Compare with highest + 1 valid
+ROM:0745    JR   NC, BadSpecif      ; Branch if parameter is GEQ 16
+ROM:0747    OR   B                  ; Combine SRT and HUT
+ROM:0748    LD  (HL), A             ; Store byte to set SRT and HUT
+ROM:0749    INC  HL
+ROM:074A    LD   A, (F.Parm3)       ; Set Head Load Time from Parameter 2
+ROM:074D    CP   128                ; Is head load time too large?
+ROM:074F    JR   NC, BadSpecify     ; Branch if Parameter too large
+ROM:0751    SLA  A                  ; Position and set to DMA move (Bit 0)
+ROM:0753    LD  (HL), A
+ROM:0754    LD   B, 3               ; Length of command
+ROM:0756    JR   SendCommand        ; Send command to the floppy
+ROM:0758 BadSpecify:
+ROM:0758    SCF                     ; Set FloppyIO failed
+ROM:0759    RET
+ROM:075A OP_Seek:
+ROM:075A    LD  (HL), FC_Seek       ; Command for seek
+ROM:075C    INC  HL
+ROM:075D    LD   A, (F.Parm1)       ; Get command options
+ROM:0760    LD  (HL), A
+ROM:0761    INC  HL
+ROM:0762    LD   A, (F.Cyl)         ; Get new cylinder number
+ROM:0765    LD  (HL), A
+ROM:0766    LD   B, 3               ; Command length
+ROM:0768    JR   SendCommand        ; Send command to the floppy
+ROM:076A SendCommand:
+ROM:076A    LD   HL, F.CmdBuf       ; Get address of command
+ROM:076D SendNext:
+ROM:076D    LD   C, 255             ; Per byte retry count
+ROM:076F SendRetry:
+ROM:076F    IN   A, (IOAFStat)      ; Get Floppy main status
+ROM:0771    BIT  7, A               ; Is floppy ready?
+ROM:0773    JR   NZ, SendReady      ; Branch if floppy ready
+ROM:0775    DEC  C
+ROM:0776    JR   NZ, SendRetry      ; Retry unless already tried too many times
+ROM:0778    SCF                     ; Set error flag
+ROM:0779    RET
+ROM:077A SendReady:
+ROM:077A    BIT  6, A               ; Check if ready for output
+ROM:077C    JR   NZ, SendError      ; Branch if byte ready from controller
+ROM:077E    LD   A, (HL)            ; Get current character
+ROM:077F    INC  HL
+ROM:0780    OUT (IOAFData), A       ; Write byte to controller
+ROM:0782    DJNZ SendNext           ; Branch if more to send
+ROM:0784    OR   A                  ; Clear Carry Bit
+ROM:0785    RET
+ROM:0786 SendError:
+ROM:0786    CALL GetResult          ; Get result from floppy
+ROM:0789    SCF                     ; Set error occured
+ROM:078A    RET
+ROM:078B GetResult:
+ROM:078B    LD  HL, F.Status + 1    ; Point to status buffer
+ROM:078E    LD  B, 0                ; Count bytes received
+ROM:0790 ResNext:
+ROM:0790    LD  C, 255              ; Per byte retry count
+ROM:0792 ResRetry:
+ROM:0792    IN  A, (IOAFStat)       ; Get Floppy main status
+ROM:0794    BIT 7, A                ; Is floppy ready?
+ROM:0796    JR  NZ, ResReady        ; Branch if floppy ready
+ROM:0798    DEC C
+ROM:0799    JR  NZ, ResRetry        ; Retry unless already tried too many times
+ROM:079B    SCF                     ; Set error flag
+ROM:079C    RET
+ROM:079D ResReady:
+ROM:079D    BIT 6, A                ; Check if ready for Input
+ROM:079F    JR  Z, ResEnd           ; Branch if ready to send to controller
+ROM:07A1    IN  A, (IOAFData)       ; Read status byte from controller
+ROM:07A3    LD  (HL), A             ; Save current byte
+ROM:07A4    INC HL
+ROM:07A5    INC B                   ; Count byte received
+ROM:07A6    JR  ResNext             ; Branch to check for more
+ROM:07A8 ResEnd:
+ROM:07A8    LD  A, B                ; Copy bytes received
+ROM:07A9    LD  B, 3                ; Type code for status length = 7
+ROM:07AB    CP  7                   ; Is this full status?
+ROM:07AD    JR  Z, ResSetType       ; Yes, set the status type
+ROM:07AF    LD  B, 2                ; Type code for status length = 1
+ROM:07B1    CP  1                   ; Was status length = 1
+ROM:07B3    JR  Z, ResSetType       ; Yes, set status type
+ROM:07B5    LD  B, 1                ; Type code for status length = 2
+ROM:07B7    CP  2                   ; Was status length = 2
+ROM:07B9    JR  Z, ResSetType       ; Yes, set status type
+ROM:07BB    LD  B, 0                ; No status present
+ROM:07BD ResSetType:
+ROM:07BD    LD   A, B
+ROM:07BE    LD  (F.Status), A       ; Set status type
+ROM:07C1    OR   A                  ; Clear carry flag
+ROM:07C2    RET
+ROM:07C3 InsCmdOpt:
+ROM:07C3    LD   A, (F.Options)     ; Get command options
+ROM:07C6    OR   B                  ; Or in the command bits
+ROM:07C7    LD  (HL), A
+ROM:07C8    INC  HL
+ROM:07C9    LD   A, (F.Parm1)       ; Get head and unit select options
+ROM:07CC    LD  (HL), A             ; Insert copy of options
+ROM:07CD    INC  HL
+ROM:07CE    RET
+ROM:07CF InsAddr:
+ROM:07CF    LD   A, (F.Cyl)         ; Get current cylinder
+ROM:07D2    LD  (HL), A
+ROM:07D3    INC  HL
+ROM:07D4    LD   A, (F.Parm1)       ; Set head number from command option bit 2
+ROM:07D7    SRA  A                  ; Shift bit 2 to bit 1
+ROM:07D9    SRA  A                  ; Shift bit 1 to bit 0
+ROM:07DB    AND  1                  ; Isolate bit 0
+ROM:07DD    LD  (HL), A
+ROM:07DE    INC  HL
+ROM:07DF    LD   A, (F.Sector)      ; Set starting sector from current sector
+ROM:07E2    LD  (HL), A
+ROM:07E3    INC  HL
+ROM:07E4    LD   A, (F.DTL)         ; Get encoded data length (N)
+ROM:07E7    LD  (HL), A
+ROM:07E8    INC  HL
+ROM:07E9    LD   A, (F.EOT)         ; Set Last sector on track
+ROM:07EC    LD  (HL), A
+ROM:07ED    INC  HL
+ROM:07EE    LD   A, (F.GPL)         ; Set Gap length on track
+ROM:07F1    LD  (HL), A
+ROM:07F2    INC  HL
+ROM:07F3    LD  (HL), 128           ; Set Data length to 128 (used only if n=0)
+ROM:07F5    INC  HL
+ROM:07F6    RET
+ROM:07F7 ;
+ROM:07F7 ; Initial
+ROM:07F7 Start:
+ROM:07F7    DI                      ; Disable all interrupts until init done
+ROM:07F8    LD   SP, BufFloppy+128      ; Default stack during initialization
+ROM:07FB    XOR  A                  ; Clear A
+ROM:07FC    LD  (RSA.Cmd), A        ; RSA command not available
+ROM:07FF    LD  (RSB.Cmd), A        ; RSB Command not available
+ROM:0802    LD  (Speech.Cmd), A     ; Speech command not available
+ROM:0805    LD  (Floppy.Cmd), A     ; Floppy command not available
+ROM:0808    LD  (KB.Cmd), A         ; Keyboard command not available
+ROM:080B    LD  (GPIB.Cmd), A       ; GPIB command not available
+ROM:081E    LD  (Clock.Cmd), A      ; Clock command not available
+ROM:0811    LD  (Z80.Cmd), A        ; Z80 command not available
+ROM:0814    LD  (Floppy.Rdy), A     ; Floppy I/O Not done
+ROM:0817    LD  (DMAPERQ), A        ; DMA to PERQ not done
+ROM:081A    LD  (DMAGPIB), A        ; DMA to GPIB not done
+ROM:081D    LD  (DMASIO), A         ; DMA to SIO not done
+ROM:0820    LD  (DMAFloppy), A      ; DMA to Floppy not done
+ROM:0823    INC  A                  ; Initialize with 1 unit available
+ROM:0824    LD  (PERQO.Cmd), A      ; PERQ output port is available
+ROM:0827    LD  (SIODMABusy), A     ; SIO DMA is available
+ROM:082A    LD  (PERQDMABusy), A    ; PERQ DMA is available
+ROM:082D    LD   A, 0
+ROM:082F    OUT (INTCSR), A         ; Reset Interrupt chip
+ROM:0831    LD   A, I.M01234|I.Fixed|I.Indiv|I.Interrupt|I.GrpLow|I.ReqHigh
+ROM:0833    OUT (INTCSR), A         ; Set Mode bits
+ROM:0835    LD   A, I.WrACR
+ROM:0837    OUT (INTCSR), A         ; Prepare to load Auto-Clear register
+ROM:0839    LD   A, 011111111B
+ROM:083B    OUT (IntData), A        ; Force all channels to autoclear 
+ROM:083D    CALL Z80Init            ; Initialize Z80 device
+ROM:0840    CALL PERQInit           ; Initialize PERQ port
+ROM:0843    CALL KBInit             ; Initialize keyboard
+ROM:0846    CALL DMAInit            ; Initialize DMA
+ROM:0849    CALL FloppyInit         ; Initialize Floppy
+ROM:084C    CALL ClockInit          ; Initialize Clock
+ROM:084F    CALL RSAInit            ; Initialize RS232 channel A
+ROM:0852    CALL RSBInit            ; Initialize RS232 channel B
+ROM:0855    CALL SPInit             ; Initialize Speech
+ROM:0858    CALL GPIBInit           ; Initialize GPIB
+ROM:085B    CALL PointInit          ; Initialize Kriz pointer
+ROM:085E    CALL InitTCBs           ; Initialize the Scheduler
+ROM:0861    LD   A, 1               ; Lowest possible priority for this task
+ROM:0863    LD   BC, LVTask         ; Entry point for the Low volume task
+ROM:0866    LD   HL, Stack1         ; Use this stack
+ROM:0869    CALL NewTask            ; Create the Low volume task
+ROM:086C    LD   A, 5               ; Priority for floppy task
+ROM:086E    LD   BC, FloppyTask     ; Start address
+ROM:0871    LD   HL, Stack2         ; Use this stack
+ROM:0874    CALL NewTask            ; Create the Floppy Task
+ROM:0877    LD   A, 5               ; Priority
+ROM:0879    LD   BC, RSATask        ; RS232 Channel A task
+ROM:087C    LD   HL, Stack3
+ROM:087F    CALL NewTask
+ROM:0882    LD   A, 5               ; Priority
+ROM:0884    LD   BC, RSBTask        ; RS232 Channel B task (Speech)
+ROM:0887    LD   HL, Stack4
+ROM:088A    CALL NewTask
+ROM:088D    LD   A, 5               ; Priority
+ROM:088F    LD   BC, GPIBTask       ; GPIB task entry point
+ROM:0892    LD   HL, Stack5
+ROM:0895    CALL NewTask
+ROM:0898    LD   A, 5               ; Priority
+ROM:089A    LD   BC, Z80Task        ; Z80 task entry point
+ROM:089D    LD   HL, Stack6
+ROM:08A0    CALL NewTask
+ROM:08A3    LD   A, 5               ; Priority
+ROM:08A5    LD   BC, SpTask         ; Speech task entry point
+ROM:08A8    LD   HL, Stack7
+ROM:08AB    CALL NewTask
+ROM:08AE    LD   A, I.M567 | I.Arm | I.RdISR
+ROM:08B0    OUT (INTCSR), A         ; Arm interrupt chip                
+ROM:08B2    LD   A, HI(Vectors)     ; Get MSB of interrupts vector area
+ROM:08B4    LD   I, A               ; Set interrupt vector page
+ROM:08B6    IM   2                  ; Set mode for vectored interrupts                
+ROM:08B8    LD   IX, (CurrTCB)      ; Default TCB to start searching
+ROM:08BC    JP   Despatch           ; Start highest priority task
+ROM:08BE ;
+ROM:08BE ; End Initial
+ROM:08BF ;
+ROM:08BF ; Keyboard
+ROM:08BF KBInit:
+ROM:08BF    XOR A
+ROM:08C0    LD  (KBIBuff), A        ; Clear PUT offset of the buffer
+ROM:08C3    LD  (KBIBuff+1), A      ; Clear GET offset of the buffer
+ROM:08C6    LD  HL, KB.Flg          ; Address of flag byte
+ROM:08C9    LD  (HL), A             ; Clear flag byte
+ROM:08CA    SET EnbFlgBit,(HL)      ; Enable the keyboard
+ROM:08CC    LD  A, CTC.KBSel | CTC.Both | CTC.M3
+ROM:08CE    OUT (CTCB.CSR), A       ; Select counter and mode
+ROM:08D0    LD  A, LO(833)          ; = 4Mhz / (300Baud * 16) = 833
+ROM:08D2    OUT (CTC.KB), A
+ROM:08D4    LD  A, HI(833)          ; High byte of 833
+ROM:08D6    OUT (CTC.KB), A
+ROM:08D8    IN  A,(KBData)          ; Clear any pending character
+ROM:08DA    IN  A,(KBData)          ; Clear any pending character
+ROM:08DC    IN  A,(KBData)          ; Clear any pending character
+ROM:08DE    LD  HL, InitTab         ; Address of initialization 
+ROM:08E1    LD  B, InitTabL         ; Total writes
+ROM:08E3    LD  C, KBControl        ; I/O Address of keyboard control
+ROM:08E5    OTIR
+ROM:08E7    RET
+ROM:08E8 ;
+ROM:08E8 ; Initialisation table for RS232
+ROM:08E8 InitTab:
+ROM:08E8    .byte  00011000B        ; Channel Reset command
+ROM:08E9    .byte          4        ; Select register 4
+ROM:08EA    .byte  01001000B        ; *16 clock, 1 1/2 stop, no parity
+ROM:08EB    .byte          3        ; Select Register 3
+ROM:08EC    .byte  11100001B        ; 8 Bits, Auto Enable, Rx Enable
+ROM:08ED    .byte          5        ; Select Register 5
+ROM:08EE    .byte  11100000B        ; DTR, 8 Bits, disable Tx
+ROM:08EF    .byte          1        ; Select register 1
+ROM:08F0    .byte  00011100B        ; Enables reciever interrupts
+ROM:08F1    .byte          2        ; Select Register 2
+ROM:08F2    .byte  LO(VecRS1)       ; Load interrupt vector
+ROM:08F3    .byte          0        ; Leave it pointing at R0
+ROM:08F3 ; InitTabL equ 12          ; Length of table
+ROM:08F3 ;
+ROM:08F4 XKB:
+ROM:08F4    LD   HL, KB.Flg         ; A useful pointer
+ROM:08F7    LD   A, (PERQIBuff+2)       ; The command byte
+ROM:08FA    CP   CmdConfig
+ROM:08FC    JR   Z, KBConfig        ; Branch if Configure command
+ROM:08FE    CP   CmdSense
+ROM:0900    JR   Z, KBSense         ; Branch if Sense command
+ROM:0902    CP   CmdReset           ; Is it Reset?
+ROM:0904    JR   NZ, NAKIt          ; Branch if invalid command
+ROM:0906    CALL KBINIT
+ROM:0909    JR   ACKIt
+ROM:090B KBSense:
+ROM:090B    SET  SRFlgBit,(HL)      ; Set the status request bit
+ROM:090D    JP   PERQEnable
+ROM:0910 KBConfig:
+ROM:0910    LD   A, (PERQIBuff+3)       ; The On/Off byte
+ROM:0913    OR   A                  ; Zero for Off?
+ROM:0914    JR   Z, KBCOff
+ROM:0916    SET  EnbFlgBit, (HL)
+ROM:0918    JR   ACKIt
+ROM:091A KBCOff:
+ROM:091A    RES  EnbFlgBit, (HL)
+ROM:091C ACKIt:
+ROM:091C    SET  ACKFlgBit, (HL)    ; Set a flag for the Low Vol Task
+ROM:091E    JP   PERQEnable
+ROM:0921 NAKIt:
+ROM:0921    SET  NAKFlgBit, (HL)    ; Set another flag for LowVol
+ROM:0923    JP   PERQEnable
+ROM:0926 ZKB:
+ROM:0926    LD   C, DevKB           ; Device code
+ROM:0928    LD   HL, KBIBuff        ; Address of input circular buffer
+ROM:092B    CALL SendData           ; Send data if any
+ROM:092E    LD   HL, KB.Flg         ; Check Keyboard for ACK/NAK
+ROM:0931    LD   A, (HL)            ; Copy of flags
+ROM:0932    AND  RespMask           ; Test for responses pending
+ROM:0934    RET  Z                  ; Return if none
+ROM:0935    LD   C, DevKB           ; Device code
+ROM:0937    BIT  ACKFlgBit, A
+ROM:0939    JP   NZ, SendACK        ; If necessary send ACK and return
+ROM:093C    BIT  NAKFlgBit, A
+ROM:093E    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:0941    BIT  SRFlgBit, A
+ROM:0943    RET  Z                  ; Return if no status to send
+ROM:0944    RES  SRFlgBit, (HL)     ; Reset Status Request pending
+ROM:0946    LD   HL, PERQO.Cmd
+ROM:0949    CALL Wait               ; Wait for output port to be free
+ROM:094C    LD   A, 4
+ROM:094E    LD  (PERQOBuff), A      ; Length of status
+ROM:0951    LD   A,DevKB
+ROM:0953    LD  (PERQOBuff+1), A    ; Insert the device code
+ROM:0956    LD   A, CmdStatus
+ROM:0958    LD  (PERQOBuff+2), A    ; Set command field to status
+ROM:095B    LD   HL, KB.Flg         ; Address of keyboard flags
+ROM:095E    XOR  A                  ; Start with a zero
+ROM:095F    BIT  OvfFlgBit, (HL)
+ROM:0961    JR   Z, NoKBOver
+ROM:0963    INC  A                  ; Non-zero flag in A
+ROM:0964 NoKBOver:
+ROM:0964    LD  (PERQOBuff+4), A    ; OVERFLOW IND FIELD
+ROM:0967    RES  OvfFlgBit, (HL)    ; Overflow flag
+ROM:0969    LD   A, (HL)            ; Get flags in A
+ROM:096A    AND  EnbBitMsk          ; Mask for enable bit
+ROM:096C    LD  (PERQOBuff+3), A    ; On/Off field
+ROM:096F    JP   SendPERQ           ; Send message, release port and return
+ROM:0972 KBRx.ISR:
+ROM:0972    EXX
+ROM:0973    EX   AF, AF
+ROM:0974    IN   A, (KBData)        ; Keyboard input port
+ROM:0976    LD   HL, KB.Flg
+ROM:0979    BIT  EnbFlgBit, (HL)    ; Check to see if the keyboard is enabled
+ROM:097B    JR   Z, KB.ISRExit      ; Branch if not enabled
+ROM:097D    CPL                     ; Data from keyboard is inverted
+ROM:097E    LD   D, A               ; Save character
+ROM:097F ; Check for keyboard buffer full
+ROM:097F    LD   HL, KBIBuff
+ROM:0982    CALL BufCmp             ; Gets chars in buff to A
+ROM:0985    CP   BuffSize-2         ; Full?
+ROM:0987    JR   C, KBFree          ; Branch if space for 2 more characters
+ROM:0989 ; Set the Keyboard overflow indicator
+ROM:0989    LD   HL, KB.Flg         ; Keyboard flag word
+ROM:098C    SET  OvfFlgBit, (HL)    ; Overflow flag
+ROM:098E    JR   KB.ISRExit         ; Go to return point
+ROM:0990 KBFree:
+ROM:0990    XOR  A
+ROM:0991    CALL BufPut             ; Store Null Status byte
+ROM:0994    LD   A, D               ; Restore character 
+ROM:0995 ; HL still points to KBIBuff
+ROM:0995    CALL BufPut             ; and store off char
+ROM:0998 KB.ISRExit:
+ROM:0998    EXX
+ROM:0999    EX  AF, AF
+ROM:099A    EI
+ROM:099B    RETI
+ROM:099D KBTx.ISR:
+ROM:099D    EXX
+ROM:099E    EX   AF, AF
+ROM:099F    LD   A, 5
+ROM:09A1    OUT (KBControl), A      ; Select write register 5
+ROM:09A3    LD   A, 0
+ROM:09A5    OUT (KBControl), A      ; Clear entire transmit register
+ROM:09A7    LD   A, RSRTIP          ; Reset transmitter interrupt pending
+ROM:09A9    OUT (KBControl), A
+ROM:09AB    EXX
+ROM:09AC    EX   AF, AF
+ROM:09AD    EI
+ROM:09AE    RETI
+ROM:09B0 KBSt.ISR:
+ROM:09B0    EXX
+ROM:09B1    EX  AF, AF
+ROM:09B2    LD  A, RSRExtInt        ; Reset external interrupt
+ROM:09B4    OUT (KBControl), A
+ROM:09B6    EXX
+ROM:09B7    EX  AF, AF
+ROM:09B8    EI
+ROM:09B9    RETI
+ROM:09BB KBSp.ISR:
+ROM:09BB    EXX
+ROM:09BC    EX  AF, AF
+ROM:09BD    LD  A, RSRError         ; Error reset
+ROM:09BF    OUT (KBControl), A
+ROM:09C1    IN  A, (KBData)         ; Discard the char
+ROM:09C3    EXX
+ROM:09C4    EX  AF, AF
+ROM:09C5    EI
+ROM:09C6    RETI
+ROM:09C7 ;
+ROM:09C7 ; End Keyboard
+ROM:09C8 ;
+ROM:09C8 ; PERQ
+ROM:09C8 PERQInit:
+ROM:09C8    LD   A, I.WrRes | I.By1 | I.PERQI ; 1 byte response for PERQ input
+ROM:09CA    OUT (INTCSR), A         ; Enable writting response memory
+ROM:09CC    LD   A, LO(VecPERQI)
+ROM:09CE    OUT (INTDATA), A        ; Set PERQ Input interrupt vector
+ROM:09D0    LD   A, I.CIMRIRR | I.PERQI | I.Single
+ROM:09D2    OUT (INTCSR), A         ; Clear IMR and IRR for PERQ input
+ROM:09D4    LD   A, I.WrRes | I.By1 | I.PERQO ; 1 byte response for PERQ output
+ROM:09D6    OUT (INTCSR), A         ; Enable writting response memory
+ROM:09D8    LD   A, LO(VecPERQO)
+ROM:09DA    OUT (INTDATA), A        ; Set PERQ Output interrupt vector
+ROM:09DC    LD   A, I.CIMRIRR | I.PERQO | I.Single
+ROM:09DE    OUT (INTCSR), A         ; Clear IMR and IRR for PERQ Output
+ROM:09E0    LD   A, PI_Empty        ; Set input state to empty
+ROM:09E2    LD  (PI.State), A
+ROM:09E5    LD   A, 1               ; Set the output ready bit so PERQ can
+ROM:09E7    OUT (PERQ.Rdy), A       ; Get interrupts when data loaded to FIFO
+ROM:09E9    RET
+ROM:09EA PERQI.ISR:
+ROM:09EA    EXX
+ROM:09EB    EX   AF, AF
+ROM:09EC    LD   A, (PI.State)      ; Get input buffer state
+ROM:09EF    DEC  A                  ; Decrement and set CCs
+ROM:09F0    JR   Z, SaveData        ; Branch if state = 1 then save data
+ROM:09F2    DEC  A                  ; Decrement and set CCs
+ROM:09F3    JR   Z, SaveCount       ; Branch if state = 2 then save count
+ROM:09F5 WaitSOM:
+ROM:09F5    IN   A, (PERQ.STS)      ; Get status of FIFOs
+ROM:09F7    BIT  6, A               ; Test if data in input fifo
+ROM:09F9    JR   NZ, IH_Exit        ; Exit if no more characters in FIFO
+ROM:09FB    IN   A, (PERQ.IN)       ; Get character from PERQ input port
+ROM:09FD    CP   SOM                ; Is it start of new packet
+ROM:09FF    JR   NZ, WaitSOM        ; Branch if not, just ignore
+ROM:0A01    LD   A, PI_Count        ; Set state to count pending
+ROM:0A03    LD  (PI.State), A       ; Fall into next state
+ROM:0A06 SaveCount:
+ROM:0A06    IN   A, (PERQ.STS)      ; Get status of FIFOs
+ROM:0A08    BIT  6, A               ; Test if data in input fifo
+ROM:0A0A    JR   NZ, IH_Exit        ; Exit if no more characters in FIFO
+ROM:0A0C    IN   A, (PERQ.IN)       ; Get character from PERQ input port
+ROM:0A0E    OR   A                  ; Check for LEQ 0
+ROM:0A0F    JR   Z, CountZero       ; Branch if count = 0
+ROM:0A11 CountNZ:
+ROM:0A11    CP   MaxMsg + 1         ; See if count > Max allowed
+ROM:0A13    JR   NC, CountOvf       ; Branch if count > Max
+ROM:0A15 CountOk:
+ROM:0A15    LD   HL, PERQIBuff      ; Reset buffer ptr to base of buffer
+ROM:0A18    LD  (HL), A             ; Store count character
+ROM:0A19    INC  HL                 ; Update address
+ROM:0A1A    LD  (PI.Addr), HL       ; Store next address
+ROM:0A1D    LD  (PI.Remain), A      ; Put count in memory
+ROM:0A20    LD   A, PI_Data         ; Set state to data code expected
+ROM:0A22    LD  (PI.State), A       ; Fall into next state
+ROM:0A25 SaveData:
+ROM:0A25    IN   A, (PERQ.STS)      ; Get status of FIFOs
+ROM:0A27    BIT  6, A               ; Test if data in input fifo
+ROM:0A29    JR   NZ, IH_Exit        ; Exit if no more characters in FIFO
+ROM:0A2B    IN   A, (PERQ.IN)       ; Get character from PERQ input port
+ROM:0A2D    LD   HL, (PI.Addr)      ; Get current input buffer pointer
+ROM:0A30    LD  (HL), A             ; Store input character
+ROM:0A31    INC  HL                 ; Update address
+ROM:0A32    LD  (PI.Addr), HL       ; Store next address
+ROM:0A35    LD   HL, PI.Remain      ; Address of remaining count
+ROM:0A38    DEC (HL)                ; Decrement count of characters remaining
+ROM:0A39    JR   NZ, SaveData       ; Branch if more to come
+ROM:0A3B    CALL PERQDisable        ; Disable PERQ input interrupts
+ROM:0A3E    LD   A, PI_Empty        ; Set input buffer state to Empty
+ROM:0A40    LD  (PI.State), A       ; Next interrupt will start filling new buffer
+ROM:0A43    CALL ExaminePacket      ; Determine what to do with packet
+ROM:0A46 IH_Exit:
+ROM:0A46    EXX
+ROM:0A47    EX  AF, AF
+ROM:0A48    EI
+ROM:0A49    RETI
+ROM:0A4B CountZero:
+ROM:0A4B    LD   A, PI_Empty        ; Set input buffer state to Empty
+ROM:0A4D    LD  (PI.State), A       ; Next interrupt will start filling new buffer
+ROM:0A50    JR   WaitSOM            ; Check for more bytes in input
+ROM:0A52 CountOvf:
+ROM:0A52    LD   A, MaxMsg          ; Set to Max size
+ROM:0A54    JR   CountOK
+ROM:0A56 ExaminePacket:
+ROM:0A56    LD  A, (PERQIBuff+1)    ; Get device number
+ROM:0A59    CP  DevFloppy           ; Is device floppy?
+ROM:0A5B    JP  Z, XFloppy          ; Yes, have floppy module handle new command
+ROM:0A5E    CP  DevRSA              ; Is device RSA?
+ROM:0A60    JP  Z, XRSA             ; Yes, have RSA module handle new command
+ROM:0A63    CP  DevRSB              ; Is device RSB?
+ROM:0A65    JP  Z, XRSB             ; Yes, have RSB module handle new command
+ROM:0A68    CP  DevSpeech           ; Is device Speech?
+ROM:0A6A    JP  Z, XSpeech          ; Yes, have Speech module handle new command
+ROM:0A6D    CP  DevGPIB             ; Is device GPIB?
+ROM:0A6F    JP  Z, XGPIB            ; Yes, have GPIB module handle new command
+ROM:0A72    CP  DevKB               ; Is device Keyboard?
+ROM:0A74    JP  Z, XKB              ; Yes, have Keyboard module handle new command
+ROM:0A77    CP  DevClock            ; Is device Clock?
+ROM:0A79    JP  Z, XClock           ; Yes, have Clock module handle new command
+ROM:0A7C    CP  DevPointer          ; Is device Pointer?
+ROM:0A7E    JP  Z, XPointer         ; Yes, have Pointer module handle new command
+ROM:0A81    CP  DevZ80              ; Is device Z80?
+ROM:0A83    JP  Z, XZ80             ; Yes, Have Z80 module handle new command
+ROM:0A86 ;
+ROM:0A86 ; Unknown device code ignore the message
+ROM:0A86    JP   PERQEnable         ; Re-enable the port and return to handler
+ROM:0A89 SendPERQ:
+ROM:0A89    LD   HL, PERQOBuff      ; Point to the buffer
+ROM:0A8C    LD   B, (HL)            ; Get message byte count
+ROM:0A8D    INC  B                  ; Total message length
+ROM:0A8E    LD   C, PERQ.OUT        ; PERQ output port address
+ROM:0A90    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0A93    LD   A, SOM             ; Send Start of message character
+ROM:0A95    OUT (C), A
+ROM:0A97 CheckBusy:
+ROM:0A97    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0A9A    OUTI 
+ROM:0A9C    JR   NZ, CheckBusy      ; If more to send check busy again
+ROM:0A9E    LD   HL, PERQO.Cmd      ; Port semaphore
+ROM:0AA1    JP   Signal             ; Return after releasing the Port
+ROM:0AA4 SendAttn:
+ROM:0AA4    DI                      ; Disable during test and clear
+ROM:0AA5    LD   A, (HL)            ; Get attention mask
+ROM:0AA6    LD  (HL), 0             ; Clear the attention mask byte
+ROM:0AA8    EI                      ; Re-enable
+ROM:0AA9    OR   A                  ; Test for attentions
+ROM:0AAA    RET  Z                  ; Return none pending
+ROM:0AAB    LD   B, A               ; Save attention reason 
+ROM:0AAC    LD   HL, PERQO.Cmd
+ROM:0AAF    CALL Wait               ; Wait for the output buffer
+ROM:0AB2    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AB5    LD   A, SOM             ; Send Start of message character
+ROM:0AB7    OUT (PERQ.OUT), A
+ROM:0AB9    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0ABC    LD   A, 3               ; Length of Attn
+ROM:0ABE    OUT (PERQ.OUT), A
+ROM:0AC0    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AC3    LD   A, C               ; Set device to send ACK for
+ROM:0AC4    OUT (PERQ.OUT), A
+ROM:0AC6    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AC9    LD   A, CmdAttn         ; Set command to attention
+ROM:0ACB    OUT (PERQ.OUT), A
+ROM:0ACD    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AD0    LD   A, B               ; Set Attention reason
+ROM:0AD1    OUT (PERQ.OUT), A
+ROM:0AD3    JP   Signal             ; Release port and return
+ROM:0AD6 SendNAK:
+ROM:0AD6    RES  NAKFlgBit, (HL)    ; Reset NAK pending
+ROM:0AD8    LD   B, CmdNAK          ; Set command to NAK
+ROM:0ADA    JP   SendAN             ; Join common
+ROM:0ADD SendACK:
+ROM:0ADD    RES  ACKFlgBit, (HL)    ; Reset ACK pending
+ROM:0ADF    LD   B, CmdACK          ; Set command to ACK
+ROM:0AE1 SendAN:
+ROM:0AE1    LD   HL, PERQO.Cmd
+ROM:0AE4    CALL Wait               ; Reserve the PERQ output port
+ROM:0AE7    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AEA    LD   A, SOM             ; Send Start of message character
+ROM:0AEC    OUT (PERQ.OUT), A
+ROM:0AEE    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AF1    LD   A, 2               ; Length of ACK/NAK
+ROM:0AF3    OUT (PERQ.OUT), A
+ROM:0AF5    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AF8    LD   A, C               ; Set device to send ACK for
+ROM:0AF9    OUT (PERQ.OUT), A
+ROM:0AFB    CALL FIFOWait           ; Wait until FIFO to PERQ not full
+ROM:0AFE    LD   A, B               ; Set command to send
+ROM:0AFF    OUT (PERQ.OUT), A
+ROM:0B01    JP   Signal             ; Release port and return
+ROM:0B04 SendData:
+ROM:0B04    CALL BufCmp             ; Compare buffer pointers
+ROM:0B07    AND  !1                 ; Send only even number of bytes
+ROM:0B09    RET  Z                  ; Return if no data in buffer
+ROM:0B0A    CP   MaxData            ; More data than will fit in one message?
+ROM:0B0C    JR   C, Enough          ; Branch if all the data will fit
+ROM:0B0E    LD   A, MaxData         ; Send maximum amount
+ROM:0B10 Enough:
+ROM:0B10    EX   DE, HL             ; Save buffer pointer
+ROM:0B11    LD   B, A               ; Save count
+ROM:0B12    LD   HL, PERQO.Cmd      ; Get output channel
+ROM:0B15    CALL Wait               ; Wait for PERQ port
+ROM:0B18    LD   A, B               ; Restore count
+ROM:0B19    ADD  A, 2               ; Bump it for command fields
+ROM:0B1B    LD   HL, PERQOBuff      ; Point to the output buffer
+ROM:0B1E    LD  (HL), A             ; And save count in the buffer
+ROM:0B1F    INC  HL                 ; Point to device section
+ROM:0B20    LD  (HL), C             ; and save device code
+ROM:0B21    INC  HL                 ; Point to command
+ROM:0B22    LD  (HL), CmdData       ; This is a data packet
+ROM:0B24    INC  HL                 ; Point to message area
+ROM:0B25    EX   DE, HL             ; Put pointer in DE, get back buffer pointer
+ROM:0B25                            ; Note B still contains byte count
+ROM:0B26    CALL BlockGet           ; Get bytes from circular buffer to message
+ROM:0B29    JP   SendPERQ           ; Send to PERQ, release port and return
+ROM:0B2C PERQDisable:
+ROM:0B2C    LD   A, I.Single | I.PERQI | I.SIMR
+ROM:0B2E    OUT (INTCSR), A         ; Set PERQ input mask register bit
+ROM:0B30    RET
+ROM:0B31 PERQEnable:
+ROM:0B31    IN   A, (PERQ.STS)      ; Get status of FIFOs
+ROM:0B33    BIT  6, A               ; Test if data in input fifo
+ROM:0B35    JR   NZ, FIFOMt         ; Branch if no characters in FIFO
+ROM:0B37    LD   A, I.Single | I.PERQI | I.SIRR
+ROM:0B39    OUT (INTCSR), A         ; Force new interrupt for FIFO
+ROM:0B3B FIFOMt:
+ROM:0B3B    LD   A, I.Single | I.PERQI | I.CIMR
+ROM:0B3D    OUT (INTCSR), A         ; Clear PERQ input mask register bit
+ROM:0B3F    RET
+ROM:0B40 GetBlkData:
+ROM:0B40    PUSH HL                 ; Save address of input semaphore
+ROM:0B41    PUSH AF                 ; Save device code
+ROM:0B42    LD   HL, PERQDMABusy    ; Address of PERQ DMA semaphore
+ROM:0B45    CALL Wait               ; Wait until DMA channel free
+ROM:0B48    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0B4B    CALL Wait               ; Wait for port to be available
+ROM:0B4E    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B51    LD   A, SOM             ; Send SOM to PERQ
+ROM:0B53    OUT (PERQ.Out), A
+ROM:0B55    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B58    LD   A, 4               ; Length of Reqdata command
+ROM:0B5A    OUT (PERQ.Out), A
+ROM:0B5C    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B5F    POP  AF                 ; Restore A
+ROM:0B60    OUT (PERQ.Out), A       ; Send device code to PERQ
+ROM:0B62    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B65    LD   A, CmdReqData      ; Send Request data command
+ROM:0B67    OUT (PERQ.Out), A
+ROM:0B69    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B6C    LD   A, C               ; Send low order byte of length to PERQ
+ROM:0B6D    OUT (PERQ.Out), A
+ROM:0B6F    CALL FIFOWait           ; Wait until FIFO not full
+ROM:0B72    LD   A, B               ; Send high order byte of length to PERQ
+ROM:0B73    OUT (PERQ.Out), A
+ROM:0B75    PUSH BC                 ; Save data byte count (Signal needs BC)
+ROM:0B76    PUSH DE                 ; Save data buffer address (Signal needs DE)
+ROM:0B77    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0B7A    CALL Signal             ; Release PERQ Output Port
+ROM:0B7D    POP  DE                 ; Restore data buffer address
+ROM:0B7E    POP  BC                 ; Restore data byte count
+ROM:0B7F    POP  HL                 ; Recover semaphore to wait on
+ROM:0B80    CALL Wait               ; Wait for command back from PERQ
+ROM:0B83    PUSH DE                 ; Save Buffer address for exit
+ROM:0B84    PUSH HL                 ; Save semaphore again
+ROM:0B85    LD   A, (PI.Command)    ; Get command byte
+ROM:0B88    CP   CmdBlkdata         ; Is it BlkData?
+ROM:0B8A    SCF                     ; Set carry for possible error exit
+ROM:0B8B    JR   NZ, GetBlkExit     ; Branch if not Block data
+ROM:0B8D    LD   HL, PI.Data1       ; Address of first Count byte
+ROM:0B90    LD   C, (HL)            ; Get Lsb of byte count
+ROM:0B91    INC  HL                 ; Increment address
+ROM:0B92    LD   B, (HL)            ; Get Msb of byte count
+ROM:0B93    XOR  A
+ROM:0B94    OUT (PDMADirect), A     ; Set direction to DMA from PERQ
+ROM:0B96    OUT (PDMAFlush), A      ; Flush DMA FIFOs
+ROM:0B98    LD   A, D.PERQ          ; DMA Channel for PERQ
+ROM:0B9A    DI
+ROM:0B9B    CALL DMAtoMem           ; Start DMA from PERQ
+ROM:0B9E    EI
+ROM:0B9F    OUT (PDMAStart), A      ; Force 1st PDMA request
+ROM:0BA1    CALL PERQEnable         ; Re-enable PERQ input interrupts
+ROM:0BA4    LD  HL, DMAPERQ
+ROM:0BA7    CALL Wait               ; Wait for DMA from PERQ to finish
+ROM:0BAA    LD  A, CmdBlkData       ; Set command to blkdata
+ROM:0BAC    OR  A                   ; Clear Carry bit for return
+ROM:0BAD GetBlkExit:
+ROM:0BAD    PUSH AF                 ; Save A and Carry bit for exit
+ROM:0BAE    PUSH BC                 ; Save byte count for exit
+ROM:0BAF    LD   HL, PERQDMABusy
+ROM:0BB2    CALL Signal             ; Release PERQ DMA channel
+ROM:0BB5    POP  BC
+ROM:0BB6    POP  AF
+ROM:0BB7    POP  HL                 ; Restore HL
+ROM:0BB8    POP  DE                 ; Restore DE
+ROM:0BB9    RET
+ROM:0BBA SendBlkData:
+ROM:0BBA    PUSH HL                 ; Save semaphore address
+ROM:0BBB    PUSH AF                 ; Save Device code
+ROM:0BBC    LD   HL, PERQDMABusy
+ROM:0BBF    CALL Wait               ; Wait until PERQ DMA channel not busy
+ROM:0BC2    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0BC5    CALL Wait               ; wait for port to be available
+ROM:0BC8    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BCB    LD   A, SOM             ; Send SOM to PERQ
+ROM:0BCD    OUT (PERQ.Out), A
+ROM:0BCF    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BD2    LD   A, 4               ; Length of Blkdata command
+ROM:0BD4    OUT (PERQ.Out), A
+ROM:0BD6    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BD9    POP  AF                 ; Restore device code
+ROM:0BDA    OUT (PERQ.Out), A       ; Send device code to PERQ
+ROM:0BDC    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BDF    LD   A, CmdBlkData      ; Send Block data command
+ROM:0BE1    OUT (PERQ.Out), A
+ROM:0BE3    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BE6    LD   A, C               ; Send low order byte of length to PERQ
+ROM:0BE7    OUT (PERQ.Out), A
+ROM:0BE9    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0BEC    LD   A, B               ; Send high order byte of length to PERQ
+ROM:0BED    OUT (PERQ.Out), A
+ROM:0BEF    PUSH BC                 ; Save byte count
+ROM:0BF0    PUSH DE                 ; Save Buffer Address
+ROM:0BF1    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0BF4    CALL Signal             ; Release PERQ Output Port
+ROM:0BF7    POP  DE                 ; Restore buffer address
+ROM:0BF8    POP  BC                 ; Restore Byte count
+ROM:0BF9    POP  HL                 ; Get semaphore address
+ROM:0BFA    CALL Wait               ; wait for ACK command
+ROM:0BFD    LD   A, (PERQIbuff+2)   ; Get command
+ROM:0C00    CP   CmdACK             ; Test for ACK
+ROM:0C02    SCF                     ; Set error flag
+ROM:0C03    JR   NZ, SendExit       ; Branch if not ACK command
+ROM:0C05    CALL PERQEnable         ; Re-enable interrupts from PERQ
+ROM:0C08    LD   A, 1               ; 1 = DMA to PERQ
+ROM:0C0A    OUT (PDMADirect), A     ; Set to write to the PERQ
+ROM:0C0C    OUT (PDMAFlush), A      ; Flush FIFOs (Data does not matter)
+ROM:0C0E    LD   A, D.PERQ          ; DMA Device is PERQ
+ROM:0C10    DI
+ROM:0C11    CALL DMAtoDEV           ; Setup to DMA using BC and DE
+ROM:0C14    EI
+ROM:0C15    LD   HL, DMAPERQ
+ROM:0C18    CALL Wait               ; Wait for DMA to finish
+ROM:0C1B    LD   A, C               ; Copy low byte of byte count
+ROM:0C1C    AND  7                  ; Test for multiple of 8 bytes
+ROM:0C1E    JR   Z, SendExit        ; Branch if multiple of 8 bytes
+ROM:0C20    OUT (PDMAStart), A      ; Force out last bytes to PERQ
+ROM:0C22 SendExit:
+ROM:0C22    PUSH AF                 ; Save A and Carry bit for exit
+ROM:0C23    LD   HL, PERQDMABusy
+ROM:0C26    CALL Signal             ; Release PERQ DMA channel
+ROM:0C29    POP  AF                 ; Restore AF
+ROM:0C2A    RET
+ROM:0C2B SendBootData:
+ROM:0C2B    PUSH HL                 ; Save semaphore address
+ROM:0C2C    PUSH AF                 ; Save Device code
+ROM:0C2D    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0C30    CALL Wait               ; wait for port to be available
+ROM:0C33    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C36    LD   A, SOM             ; Send SOM to PERQ
+ROM:0C38    OUT (PERQ.Out), A
+ROM:0C3A    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C3D    LD   A, 4               ; Length of Blkdata command
+ROM:0C3F    OUT (PERQ.Out), A
+ROM:0C41    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C44    POP  AF                 ; Restore device code
+ROM:0C45    OUT (PERQ.Out), A       ; Send device code to PERQ
+ROM:0C47    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C4A    LD   A, CmdBlkData      ; Send Block data command
+ROM:0C4C    OUT (PERQ.Out), A
+ROM:0C4E    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C51    LD   A, C               ; Send low order byte of length to PERQ
+ROM:0C52    OUT (PERQ.Out), A
+ROM:0C54    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C57    LD   A, B               ; Send high order byte of length to PERQ
+ROM:0C58    OUT (PERQ.Out), A
+ROM:0C5A    POP  HL                 ; Trash semaphore address
+ROM:0C5B    EX   DE, HL             ; Move address of buffer to HL
+ROM:0C5C    XOR  A
+ROM:0C5D    CP   C                  ; Test for any bytes in page
+ROM:0C5E    LD   D, B               ; Move page count to D
+ROM:0C5F    LD   B, C               ; Set byte count in page
+ROM:0C60    LD   C, PERQ.Out        ; Load C with PERQ output port address
+ROM:0C62    JR   Z, SendPage        ; Branch if no bytes in 1st page
+ROM:0C64 SendWait:
+ROM:0C64    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C67    OUTI                    ; Send bytes down to multiple of 256 left
+ROM:0C69    JR   NZ, SendWait       ; Repeat while more to send
+ROM:0C6B SendPage:
+ROM:0C6B    LD   A, D               ; Copy for test
+ROM:0C6C    OR   A                  ; Set condition codes for A
+ROM:0C6D    JR   Z, SendDone        ; Branch if no more to send
+ROM:0C6F SendAgain:
+ROM:0C6F    CALL FIFOWait           ; Wait until room in FIFO to PERQ
+ROM:0C72    OUTI                    ; Send 256 bytes to the PERQ
+ROM:0C74    JR   NZ, SendAgain      ; Repeat while more to send
+ROM:0C76    DEC  D                  ; Decrement count of blocks
+ROM:0C77    JR   NZ, SendAgain      ; If more blocks then send again
+ROM:0C79 SendDone:
+ROM:0C79    LD   HL, PERQO.Cmd      ; Address of PERQ output semaphore
+ROM:0C7C    CALL Signal             ; Release PERQ Output Port
+ROM:0C7F    XOR  A                  ; Clear the carry bit
+ROM:0C80    RET
+ROM:0C81 PERQO.ISR:
+ROM:0C81    EXX
+ROM:0C82    EX   AF, AF
+ROM:0C83    LD   A, I.PERQO | I.Single | I.SIMR
+ROM:0C85    OUT (INTCSR), A         ; Set mask bit for PERQ output interrupts
+ROM:0C87    EXX
+ROM:0C88    EX   AF, AF
+ROM:0C89    EI
+ROM:0C8A    RETI
+ROM:0C8C FIFOWait:
+ROM:0C8C    IN  A, (PERQ.Sts)       ; Get PERQ status
+ROM:0C8E    BIT 7, A                ; Test FIFO to PERQ full
+ROM:0C90    RET NZ                  ; Return if not full
+ROM:0C91    JR  FIFOWait            ; Go wait again
+ROM:0C92 ;
+ROM:0C92 ; End PERQ
+ROM:0C93 ;
+ROM:0C93 ; Speech
+ROM:0CC1 ; End Speech
+ROM:0CC2 ;
+ROM:0CC2 ; Task Control
+ROM:0CC2 InitTCBs:
+ROM:0CC2    LD   A, TskDead         ; To fill in the task state
+ROM:0CC4    LD   HL, TCBBase        ; Base of the TCB array
+ROM:0CC7    LD  (CurrTCB), HL       ; Provide pointer into list
+ROM:0CCA    LD   DE, TCBSize        ; For stepping through
+ROM:0CCD    LD   B, NTCBs
+ROM:0CCF TCBLoop:
+ROM:0CCF    PUSH HL
+ROM:0CD0    POP  IX                 ; LD IX,HL
+ROM:0CD2    ADD  HL, DE             ; Point to next TCB
+ROM:0CD3    LD  (IX + TskNxtLo), L
+ROM:0CD6    LD  (IX + TskNxtHi), H
+ROM:0CD9    LD  (IX + TskState), A
+ROM:0CDC    DJNZ TCBLoop
+ROM:0CDC ; The last one now has to be pointed back to the first
+ROM:0CDE    LD   HL, TCBBase
+ROM:0CE1    LD  (IX + TskNxtLo), L
+ROM:0CE4    LD  (IX + TskNxtHi), H
+ROM:0CE7    RET
+ROM:0CE8 Wait:
+ROM:0CE8    DI                      ; Must be Indivisible
+ROM:0CE9    DEC (HL)
+ROM:0CEA    JP   P, Wait1           ; Semaphore was > 0
+ROM:0CEA ; Here we are going to wait, so we set the reason in our TCB
+ROM:0CED    LD   IX, (CurrTCB)
+ROM:0CF1    LD   A, TskWait
+ROM:0CF3    LD  (IX + TskState), A
+ROM:0CF6    LD  (IX + TskSemLo), L
+ROM:0CF9    LD  (IX + TskSemHi), H
+ROM:0CFC    CALL CPUGive            ; Give up the CPU
+ROM:0CFF    JP   Wait               ; Try again when the semaphore is signalled
+ROM:0D02 ;
+ROM:0D02 ; Here the Semaphore was OK, so we carry on...
+ROM:0D02 Wait1:
+ROM:0D02    EI
+ROM:0D03    RET
+ROM:0D04 Signal:
+ROM:0D04    LD  C, 0                ; Using C as a flag, assume interupts off
+ROM:0D06    LD  A, R                ; Reading R will copy IFF2 into Parity flag
+ROM:0D08    JP  PO, DoSignal        ; Branch if interrupts are indeed off
+ROM:0D0B    INC C                   ; Flag interrupts on
+ROM:0D0C    DI                      ; Now turn them off
+ROM:0D0D DoSignal:
+ROM:0D0D    LD   A, (HL)
+ROM:0D0E    OR   A
+ROM:0D0F    JP   P, NoWaiting       ; Semaphore non-negative so no-one is waiting
+ROM:0D12 ; If someone was waiting, then we must wake them up
+ROM:0D12    PUSH IX                 ; Save IX for caller
+ROM:0D14    LD   IX, (CurrTCB)      ; Our TCB is a hook into the TCB list
+ROM:0D18 ; We know that WE are not waiting, so we skip our TCB
+ROM:0D18    LD   B, NTCBs-1         ; The number remaining on the list
+ROM:0D1A SigLoop:
+ROM:0D1A    LD   D, (IX + TskNxtHi) ; Chain down to next TCB
+ROM:0D1D    LD   E, (IX + TskNxtLo)
+ROM:0D20    PUSH DE
+ROM:0D21    POP  IX                 ; DE and IX will always point to the SAME place
+ROM:0D23    LD   A, (DE)            ; First entry in TCB is task state
+ROM:0D24    CP   TskWait            ; Is this one waiting?
+ROM:0D26    JR   NZ, SigNext
+ROM:0D28    LD   A, (IX + TskSemLo) ; Is it waiting on this semaphore?
+ROM:0D2B    CP   L
+ROM:0D2C    JR   NZ, SigNext
+ROM:0D2E    LD   A, (IX + TskSemHi)
+ROM:0D31    CP   H
+ROM:0D32    JR   NZ, SigNext
+ROM:0D34    LD   A, TskRun
+ROM:0D36    LD  (DE), A             ; Wake it up
+ROM:0D37    INC (HL)                ; Counting upwards towards zero
+ROM:0D38    JR   Z, SDone
+ROM:0D3A SIGNext:
+ROM:0D3A    DJNZ SigLoop            ; Any more candidates?
+ROM:0D3C SDone:
+ROM:0D3C    POP  IX                 ; Restore IX for caller
+ROM:0D3E NoWaiting:
+ROM:0D3E    INC (HL)                ; Now actually fix the semaphore
+ROM:0D3F    LD   A,C
+ROM:0D40    OR   A                  ; Were interrupts on?
+ROM:0D41    RET  Z
+ROM:0D42    EI
+ROM:0D43    RET
+ROM:0D44 CPUGive:
+ROM:0D44    DI                      ; Make quite sure!
+ROM:0D45    PUSH IY
+ROM:0D47    PUSH IX
+ROM:0D49    PUSH HL
+ROM:0D4A    PUSH DE
+ROM:0D4B    PUSH BC
+ROM:0D4C    PUSH AF
+ROM:0D4D    LD   HL, 0
+ROM:0D50    ADD  HL, SP
+ROM:0D51    LD   IX, (CurrTCB)
+ROM:0D55    LD  (IX + TskSPLo), L
+ROM:0D58    LD  (IX + TskSPHi), H
+ROM:0D5B Despatch:
+ROM:0D5B    LD   B, NTCBs           ; The total number of TCBs in the system
+ROM:0D5D    LD   C, 0               ; Best priority so far
+ROM:0D5F PriLoop:
+ROM:0D5F    LD   A, (IX + TskState) ; Check each tasks state
+ROM:0D62    CP   TskRun
+ROM:0D64    JR   NZ, DespNxt        ; Branch if not runable
+ROM:0D66    LD   A, (IX + TskPrio)  ; Compare its priority
+ROM:0D69    CP   C
+ROM:0D6A    JR   C, DespNxt         ; Lower than the best
+ROM:0D6C    PUSH IX
+ROM:0D6E    POP  HL                 ; HL points to best
+ROM:0D6F    LD   C, A               ; C picks up its priority
+ROM:0D70 DespNxt:
+ROM:0D70    LD   D, (IX + TskNxtHi) ; Chain to next TCB
+ROM:0D73    LD   E, (IX + TskNxtLo)
+ROM:0D76    PUSH DE
+ROM:0D77    POP  IX
+ROM:0D79    DJNZ PriLoop
+ROM:0D7B ; At this point we should have a non-zero priority in C, and HL
+ROM:0D7B ; should point to the TCB
+ROM:0D7B    LD   A, C
+ROM:0D7C    OR   A
+ROM:0D7D    JR   Z, PANIC           ; Something wrong!
+ROM:0D7F    LD  (CurrTCB), HL
+ROM:0D82    LD   IX, (CurrTCB)      ; Pick up TCB pointer
+ROM:0D86    LD   L, (IX + TskSPLo)
+ROM:0D89    LD   H, (IX + TskSPHi)
+ROM:0D8C    LD   SP, HL
+ROM:0D8D    POP  AF
+ROM:0D8E    POP  BC
+ROM:0D8F    POP  DE
+ROM:0D90    POP  HL
+ROM:0D91    POP  IX
+ROM:0D93    POP  IY
+ROM:0D95    EI
+ROM:0D96    RET
+ROM:0D97 PANIC:
+ROM:0D97    HALT
+ROM:0D98 Snooze:
+ROM:0D98    LD   A, 1               ; To be our new priority
+ROM:0D9A    LD   IX, (CurrTCB)      ; Current TCB is Our TCB!
+ROM:0D9E    LD   B, (IX + TskPrio)  ; Save the old priority
+ROM:0DA1    LD  (IX + TskPrio), A   ; Set the new one
+ROM:0DA4    CALL CPUGive
+ROM:0DA7    LD  (IX + TskPrio), B   ; Set it back again
+ROM:0DAA    RET
+ROM:0DAB NewTask:
+ROM:0DAB    PUSH AF
+ROM:0DAC    PUSH BC                 ; Save them for later
+ROM:0DAD    LD   IX, (CurrTCB)      ; Hook into list
+ROM:0DB1    LD   B, NTCBs           ; Loop Count
+ROM:0DB3 FindFree:
+ROM:0DB3    LD   A, (IX + TskState)
+ROM:0DB6    CP   TskDead
+ROM:0DB8    JR   NZ, FindNxt        ; Branch if not empty task slot
+ROM:0DBA    POP  BC
+ROM:0DBB    POP  AF
+ROM:0DBC    LD  (IX + TskPrio), A
+ROM:0DBF    DEC  HL                 ; "Push" the PC on the new stack
+ROM:0DC0    LD  (HL), B
+ROM:0DC1    DEC  HL
+ROM:0DC2    LD  (HL), C
+ROM:0DC3    LD   BC, 12             ; Offset for register save area
+ROM:0DC6    OR   A                  ; Clear Carry
+ROM:0DC7    SBC  HL, BC
+ROM:0DC9    LD  (IX + TskSPHi), H   ; Set initial stack pointer
+ROM:0DCC    LD  (IX + TskSPLo), L
+ROM:0DCF    LD   A, TskRun
+ROM:0DD1    LD  (IX + TskState), A  ; Make it runnable!
+ROM:0DD4    RET
+ROM:0DD5 FindNxt:
+ROM:0DD5    LD   D, (IX + TskNxtHi) ; Link to next task
+ROM:0DD8    LD   E, (IX + TskNxtLo)
+ROM:0DDB    PUSH DE
+ROM:0DDC    POP  IX
+ROM:0DDE    DJNZ FindFree           ; Loop until scanned every slot
+ROM:0DE0 ; Here we failed to find a task... we boobed somewhere.
+ROM:0DE0 ; Maybe if we just return, and ignore this it will go away?!!
+ROM:0DE0    POP  BC
+ROM:0DE1    POP  AF                 ; Tidy up some...
+ROM:0DE2    RET                     ; and sneak away
+ROM:0DE2 ; End Task Control
+ROM:0DE3 ;
+ROM:0DE3 ; Utility
+ROM:0DE3 BufGet:
+ROM:0DE3    INC  HL                 ; HL Now points to the GET
+ROM:0DE4    LD   C, (HL)            ; Pick up GET
+ROM:0DE5    LD   B, 0               ; 16 bit value
+ROM:0DE7    PUSH HL                 ; Remember for later
+ROM:0DE8 ; Next character is at (HL + Get + 1)
+ROM:0DE8 ; The number GET+1 is a result we want later, so...
+ROM:0DE8    INC  C                  ; It will not overflow into B
+ROM:0DE9    ADD  HL, BC             ; Do the rest of the calculation
+ROM:0DEA    LD   B, (HL)            ; Pick up char
+ROM:0DEB    POP  HL                 ; Restore pointer to GET
+ROM:0DEC    LD   A, C               ; Pick up incremented GET again
+ROM:0DED    AND  MaxBuff            ; Wrap it around
+ROM:0DEF    LD  (HL), A             ; Save it off
+ROM:0DF0    DEC  HL                 ; Point Back to PUT pointer
+ROM:0DF1    LD   A, B               ; Char in A for completeness
+ROM:0DF2    RET
+ROM:0DF3 BufPut:
+ROM:0DF3    LD   C, (HL)            ; Pick up PUT
+ROM:0DF4    LD   B, 0
+ROM:0DF6 ; Next entry is at (HL + PUT + 2)
+ROM:0DF6 ; We need PUT+1, so we grab it for cheapness here
+ROM:0DF6    INC  C
+ROM:0DF7    INC  HL                 ; This gets the other +1, also points to GET
+ROM:0DF8    PUSH HL                 ; Save this pointer to GET for later
+ROM:0DF9    ADD  HL, BC             ; Calculate the address we wanted
+ROM:0DFA    LD  (HL), A             ; Save the char
+ROM:0DFB    POP  HL                 ; HL now points to GET
+ROM:0DFC    LD   A, C               ; Pick up modified PUT
+ROM:0DFD    AND  MaxBuff            ; Wrap around
+ROM:0DFF    CP  (HL)                ; Any Overrun?
+ROM:0E00    DEC  HL                 ; Point to PUT
+ROM:0E01    RET  Z                  ; Then do not save updated PUT
+ROM:0E02    LD  (HL), A             ; Save new version
+ROM:0E03    RET
+ROM:0E04 BufCmp:
+ROM:0E04    LD   A, (HL)
+ROM:0E05    INC  HL
+ROM:0E06    SUB (HL)
+ROM:0E07    DEC  HL                 ; Makes HL back the way it was
+ROM:0E08    AND  MaxBuff
+ROM:0E0A    RET
+ROM:0E0B BlockPut:
+ROM:0E0B    LD   A, B
+ROM:0E0C    OR   A
+ROM:0E0D    RET  Z
+ROM:0E0E BlPutLoop:
+ROM:0E0E    PUSH BC
+ROM:0E0F    LD   A, (DE)
+ROM:0E10    CALL BufPut
+ROM:0E13    INC  DE
+ROM:0E14    POP  BC
+ROM:0E15    DJNZ BLPutLoop
+ROM:0E17    RET
+ROM:0E18 BlockGet:
+ROM:0E18    LD   A, B
+ROM:0E19    OR   A
+ROM:0E1A    RET  Z                  ; In case he said zero bytes?
+ROM:0E1B    INC  HL                 ; Point at the GET value
+ROM:0E1C BlGetLoop:
+ROM:0E1C    PUSH BC                 ; Remember the count
+ROM:0E1D    LD   C,(HL)             ; Pick up GET value
+ROM:0E1E    LD   B,0                ; Extend to 16 bits
+ROM:0E20    INC  C                  ; Bump the GET counter
+ROM:0E21    PUSH HL                 ; Save our buffer pointer
+ROM:0E22    ADD  HL,BC              ; And add GET into the buffer pointer
+ROM:0E23    LD   A,(HL)             ; Pick up the char
+ROM:0E24    LD  (DE),A              ; and store it off
+ROM:0E25    POP  HL                 ; Get back buffer pointer
+ROM:0E26    LD   A, C               ; Pick up incremented GET
+ROM:0E27    AND  MaxBuff            ; Wrap it around
+ROM:0E29    LD  (HL),A              ; and store it back
+ROM:0E2A    INC  DE                 ; Crank up the destination pointer
+ROM:0E2B    POP  BC                 ; Fetch back the counter
+ROM:0E2C    DJNZ BlGetLoop          ; And decrement
+ROM:0E2E    RET
+ROM:0E2F BlockHide:
+ROM:0E2F    DI
+ROM:0E30    LD   C,(HL)             ; Pick up current PUT
+ROM:0E31 HideLp:
+ROM:0E31    PUSH BC                 ; Hide count
+ROM:0E32    LD   A, (DE)
+ROM:0E33    CALL BufPut             ; Put byte away
+ROM:0E36    INC  DE                 ; Step to next
+ROM:0E37    POP  BC                 ; Get back count
+ROM:0E38    DJNZ HideLp
+ROM:0E3A    LD   B, (HL)            ; Pick up new PUT value
+ROM:0E3B    LD  (HL), C             ; Save off old one
+ROM:0E3C    EI
+ROM:0E3D    RET
+ROM:0E3E Case:
+ROM:0E3E    POP  HL                 ; Return address = table address
+ROM:0E3F    LD   B, 0               ; Clear upper byte of offset
+ROM:0E41    ADD  HL, BC             ; Add 2 * BC to HL
+ROM:0E42    ADD  HL, BC
+ROM:0E43    LD   E, (HL)            ; Extract low byte of destination addr
+ROM:0E44    INC  HL
+ROM:0E45    LD   D, (HL)            ; Extract high byte of destination addr
+ROM:0E46    EX   DE, HL             ; Put destination in HL for JP (HL)
+ROM:0E47    JP  (HL)                ; Dispatch
+ROM:0E48 GetDMACount:
+ROM:0E48    OR   A                  ; Clear the carry bit
+ROM:0E49    SBC  HL, BC             ; Subtract from remaining count
+ROM:0E4B    JR   NC, GetDMA1        ; Branch if HL >= 0
+ROM:0E4D    ADD  HL, BC             ; Restore remaining count
+ROM:0E4E    LD   B, H               ; Set BC to remaining count
+ROM:0E4F    LD   C, L
+ROM:0E50    XOR  A
+ROM:0E51    LD   L, A               ; Zero remaining count
+ROM:0E52    LD   H, A
+ROM:0E53 GetDMA1:
+ROM:0E53    RET
+ROM:0E54 Drain:
+ROM:0E54    OR   A                  ; Clears the carry flag
+ROM:0E55    BIT  AwkFlgBit, (HL)    ; Is device idle yet?
+ROM:0E57    RET  Z                  ; Return carry clear if idle
+ROM:0E58    CALL Snooze             ; Not idle, give up CPU for awhile
+ROM:0E5B    JP   Drain
+ROM:0E5E FlushIn:
+ROM:0E5E    LD   B, 3               ; Three SendDatas will flush the buffer
+ROM:0E60 FlushLoop:
+ROM:0E60    CALL  BufCmp            ; See if any bytes in the input buffer
+ROM:0E63    OR    A                 ; Set Z
+ROM:0E64    RET   Z                 ; Leave if no bytes in buffer
+ROM:0E65    PUSH  BC                ; Save counter, device pointer
+ROM:0E66    PUSH  HL                ; Save input buffer pointer
+ROM:0E67    CALL  SendData          ; Send up to 12 bytes to the PERQ
+ROM:0E6A    POP   HL                ; Retrieve input buffer pointer
+ROM:0E6B    CALL  Snooze            ; Let other tasks get in
+ROM:0E6E    POP   BC                ; Retrieve counter, device pointer
+ROM:0E6F    DJNZ  Flushloop         ; Loop again if we aren't finished
+ROM:0E71    RET
+ROM:0E71 ; End Utility
+ROM:0E72 ;
+ROM:0E72 ; Z80
+ROM:0E72 Z80Init:
+ROM:0E72    XOR  A
+ROM:0E73    LD  (Z80.Flg), A        ; Clear Z80 flag byte
+ROM:0E76    RET
+ROM:0E77 XZ80:
+ROM:0E77    LD   HL, Z80.Cmd
+ROM:0E7A    LD   A, (PERQIBuff+2)   ; Get command byte
+ROM:0E7D    CP   CmdSense
+ROM:0E7F    JP   NZ, Signal         ; Signal if not sense command
+ROM:0E82    LD   HL, Z80.Flg        ; Point at flag byte
+ROM:0E85    SET  SRFlgBit, (HL)     ; Cue low volume task to send status
+ROM:0E87    JP   PERQEnable         ; Re-enable PERQ input and return
+ROM:0E8A ZZ80:
+ROM:0E8A    LD   HL, Z80.Flg        ; Check Z80 for ACK/NAK/Status
+ROM:0E8D    LD   A, (HL)
+ROM:0E8E    AND  RespMask           ; Test for any response pending
+ROM:0E90    RET  Z                  ; Return if no responses pending
+ROM:0E91    LD   C, DevZ80          ; Device code
+ROM:0E93    BIT  ACKFlgBit, A
+ROM:0E95    JP   NZ, SendACK        ; If necessary send ACK and return
+ROM:0E98    BIT  NAKFlgBit, A
+ROM:0E9A    JP   NZ, SendNAK        ; If necessary send NAK and return
+ROM:0E9D    BIT  SRFlgBit, A
+ROM:0E9F    RET  Z                  ; Return if no status to send
+ROM:0EA0    RES  SRFlgBit, (HL)     ; Reset request status pending
+ROM:0EA2    LD   HL, PERQO.Cmd
+ROM:0EA5    CALL Wait               ; Wait for output port to be free
+ROM:0EA8    LD   HL, PERQOBuff      ; Address of PERQ output buffer
+ROM:0EAB    LD   A, 4
+ROM:0EAD    LD  (HL), A             ; Length of status
+ROM:0EAE    INC  HL
+ROM:0EAF    LD   A, DevZ80
+ROM:0EB1    LD  (HL), A             ; Insert the device code
+ROM:0EB2    INC  HL
+ROM:0EB3    LD   A, CmdStatus
+ROM:0EB5    LD  (HL), A             ; Set command field to status
+ROM:0EB6    INC  HL
+ROM:0EB7    LD   A, VerMinor
+ROM:0EB9    LD  (HL), A             ; Return minor version
+ROM:0EBA    INC  HL
+ROM:0EBB    LD   A, VerMajor
+ROM:0EBD    LD  (HL), A             ; Return Major version
+ROM:0EBE    JP   SendPERQ           ; Send Status to the PERQ
+ROM:0EC1 Z80Task:
+ROM:0EC1    LD   HL, Z80.Cmd
+ROM:0EC4    CALL Wait               ; Wait for command
+ROM:0EC7 RetryCmd:
+ROM:0EC7    LD   HL, PERQIBuff+2    ; Address of PERQ input command area
+ROM:0ECA    LD   A, (HL)            ; Get command
+ROM:0ECB    CP   CmdHVI
+ROM:0ECD    JR   Z, DoHVI           ; Branch if High Volume Input
+ROM:0ECF    CP   CmdHVO
+ROM:0ED1    JR   Z, DoHVO           ; Branch if High Volume Output
+ROM:0ED3    CP   CmdReg
+ROM:0ED5    JR   Z, DoWriteReg      ; Branch if write register command
+ROM:0ED7 EnbNAK:
+ROM:0ED7    CALL PERQEnable         ; Re-enable PERQ input interrupts
+ROM:0EDA Z80NAK:
+ROM:0EDA    LD   HL, Z80.Flg
+ROM:0EDD    LD   C, DevZ80
+ROM:0EDF    CALL SendNAK            ; Force NAK for other commands
+ROM:0EE2    JP   Z80Task            ; Check again
+ROM:0EE5 EnbACK:
+ROM:0EE5    CALL PERQEnable         ; Re-enable PERQ input interrupts
+ROM:0EE8 Z80ACK:
+ROM:0EE8    LD   HL, Z80.Flg
+ROM:0EEB    LD   C, DevZ80
+ROM:0EED    CALL SendACK            ; Force ACK for command
+ROM:0EF0    JP   Z80Task            ; Check again
+ROM:0EF3 DoHVI:
+ROM:0EF3    LD   DE, (PERQIBuff+3)  ; Get address to dump
+ROM:0EF7    LD   BC, (PERQIBuff+5)  ; Get length to dump
+ROM:0EFB    CALL PERQEnable         ; Re-enable PERQ input interrupts
+ROM:0EFE    LD   A, B               ; Get HI(count)
+ROM:0EFF    OR   C                  ; OR LO(Count)  Set CCs from length
+ROM:0F00    LD   HL, Z80.Cmd        ; Point to command flag
+ROM:0F03    LD   A, DevZ80          ; Device to source data
+ROM:0F05    CALL NZ, SendBlkData    ; If non-zero length send the data
+ROM:0F08    JP   NC, Z80ACK         ; ACK and get next command if no error
+ROM:0F0B ;  We end up here if SendBlkData failed, i.e., we did not get ACK from PERQ
+ROM:0F0B ;  to send data. Instead, we got a new cmd for Z80 - go handle it
+ROM:0F0B    LD   HL, Z80.Flg
+ROM:0F0E    LD   C, DevZ80
+ROM:0F10    CALL SendNAK            ; Force NAK
+ROM:0F13    JP   RetryCmd           ; Go handle the new cmd
+ROM:0F16 DoHVO:
+ROM:0F16    LD   DE, (PERQIBuff+3)  ; Get address to load
+ROM:0F1A    LD   BC, (PERQIBuff+5)  ; Get length to load
+ROM:0F1E    CALL PERQEnable         ; Re-enable PERQ input interrupts
+ROM:0F21    LD   A, B               ; Get HI(count)
+ROM:0F22    OR   C                  ; OR LO(Count)  Set CCs from length
+ROM:0F23    LD   HL, Z80.Cmd        ; Point to command flag
+ROM:0F26    LD   A, DevZ80          ; Device to source data
+ROM:0F28    CALL NZ, GetBlkData     ; If non-zero length Get the data
+ROM:0F2B    JP   NC, Z80ACK         ; ACK and get next command if no error
+ROM:0F2E ;  We end up here if GetBlkData failed, i.e., we did not get a BlkData cmd
+ROM:0F2E ;  from PERQ. Instead, we got a new cmd for Z80 - go handle it
+ROM:0F2E    LD   HL, Z80.Flg
+ROM:0F31    LD   C, DevZ80
+ROM:0F33    CALL SendNAK            ; Force NAK
+ROM:0F36    JP   RetryCmd           ; Go handle the new cmd
+ROM:0F39 DoWriteReg:
+ROM:0F39    LD   HL, (PERQIBuff+3)  ; Get the starting address
+ROM:0F3C    PUSH HL                 ; Save address to call
+ROM:0F3D    CALL PERQEnable         ; Re-enable input interrupts
+ROM:0F40    LD   HL, Z80.Flg
+ROM:0F43    LD   C, DevZ80
+ROM:0F45    CALL SendACK            ; Send ACK for command
+ROM:0F48    POP  HL                 ; Restore address to call
+ROM:0F49    CALL Jump               ; Force return address to stack
+ROM:0F4C    JP   Z80Task            ; Check for another command
+ROM:0F4F Jump:
+ROM:0F4F    JP  (HL)                ; Call address specified in the message
+ROM:0F4F ; End Z80
 ROM:0FFF ; End of ROM
-RAM:4000 ; Start of RAM
+RAM:6800 ;
+RAM:6800 ; Start of Data
+RAM:6800 PERQO.Cmd      ; PERQ output port available
+RAM:6801 RSA.Cmd        ; RSA Command available
+RAM:6802 RSB.Cmd        ; RSB Command available
+RAM:6803 Speech.Cmd     ; Speech Command available
+RAM:6804 Floppy.Cmd     ; Floppy Command available
+RAM:6805 KB.Cmd         ; Keyboard Command available
+RAM:6806 GPIB.Cmd       ; GPIB Command available
+RAM:6807 Clock.Cmd      ; Clock Command available
+RAM:6808 Z80.Cmd        ; Z80 Command available
+RAM:6809 RSA.Flg        ; RSA Flag byte
+RAM:680A RSB.Flg        ; RSB Flag byte
+RAM:680B Speech.Flg     ; Speech Flag byte
+RAM:680C Floppy.Flg     ; Floppy Flag byte
+RAM:680D KB.Flg         ; Keyboard Flag byte
+RAM:680E GPIB.Flg       ; GPIB Flag byte
+RAM:680F Clock.Flg      ; Clock Flag byte
+RAM:6810 Kriz.Flg       ; Pointing device flag byte
+RAM:6811 Z80.Flg        ; Z80 device flag
+RAM:6812 PI.State       ; Current input state
+RAM:6813 PI.Addr        ; Current buffer address
+RAM:6815 PERQOBuff:     ; Buffer for messages to PERQ
+RAM:6824 PERQIBuff:     ; Input buffer (Count + 14 data bytes)
+RAM:6824 PI.Count       ;   Byte containing length of packet
+RAM:6825 PI.Device      ;   Byte containing device code
+RAM:6826 PI.Command     ;   Byte containing command code
+RAM:6827 PI.Byte1       ;   First data byte
+RAM:6827 PI.Data1       ;   First data byte (alias)
+RAM:6828 PI.Byte2       ;   Second data byte
+RAM:6829 PI.Byte3       ;   Third data byte
+RAM:682A PI.Byte4       ;   Fourth data byte
+RAM:682B PI.Byte5       ;   Fifth data byte
+RAM:6833 PI.Remain      ;   Number of data bytes yet to be received
+RAM:6834 Floppy.Rdy     ; Floppy IO done semaphore
+RAM:6835 F.EOT          ; Highest sector number on track
+RAM:6836 F.GPL          ; Encoded Gap length
+RAM:6837 F.DTL          ; Encoded Data length
+RAM:6838 F.Options      ; Contains 3 bits (7/MT, 6/MF, 5/SK)
+RAM:6839 F.Cyl          ; Current Cylinder
+RAM:683A F.Sector       ; Current sector
+RAM:683B F.ByteCnt      ; Count of bytes left to be transfered
+RAM:683D F.Command      ; Parameter byte 0
+RAM:683E F.Parm1        ; Parameter byte 1
+RAM:683F F.Parm2        ; Parameter byte 2
+RAM:6840 F.Parm3        ; Parameter byte 3
+RAM:6841 F.Parm4        ; Parameter byte 4
+RAM:6842 F.Parm5        ; Parameter byte 5
+RAM:6843 F.CmdBuf       ; Buffer for command
+RAM:684C F.Status       ; Type of status and up to 7 status bytes
+RAM:6854 Flop.Ratn      ; Floppy attention reason bit mask
+RAM:6855 DMADone:       ; Done semaphores for DMA to/from PERQ:
+RAM:6855 DMAFloppy      ;   DMADone + D.Floppy
+RAM:6856 DMAGPIB        ;   DMADone + D.GPIB
+RAM:6857 DMASIO         ;   DMADone + D.SIO
+RAM:6858 DMAPERQ        ;   DMADone + D.PERQ
+RAM:6859 SIODMABusy     ; Semaphore to arbitrate use of SIO DMA
+RAM:685A PERQDMABusy    ; Semaphore to arbitrate use of DMA to PERQ
+RAM:685B AdrGPIB        ; Buffer addresses for DMA
+RAM:685F AdrSIO         ; Buffer addresses for DMA
+RAM:6863 AdrFloppy      ; Buffer addresses for DMA
+RAM:6867 DMA.GNBC       ; GPIB Next Byte Cnt (Flags are bits 15,14)
+RAM:6869 DMA.GNAdr      ; GPIB Next Address
+RAM:686B DMA.SNBC       ; SIO Next Byte Cnt (Flags are bits 15,14)
+RAM:686D DMA.SNAdr      ; SIO Next Address
+RAM:686F GPR0Image      ; Image of write register 0
+RAM:6870 GPIB.RegSave   ; GPIB register save area
+RAM:6878 GPIB.Ratn      ; GPIB attention reason bit mask
+RAM:6879 GPIBIBuff      ; Input circular buffer for GPIB
+RAM:689B GPIBOBuff      ; Output circular buffer for GPIB
+RAM:68BD GPIBCmdStatus  ; Flag used for HiVol, DevRead/Write cmds
+RAM:68BE GPIBReadCnt    ; Bytes to read cnt for DevRead cmd
+RAM:68BF RSA.Ratn       ; Rs232 A attention reason bit mask
+RAM:68C0 RSAIBuff       ; Input circular buffer
+RAM:68E2 RSAOBuff       ; Output circular buffer
+RAM:6904 RSA.RR1
+RAM:6905 RSA.RR0
+RAM:6906 RSAHVStatus    ; Non-zero is abnormal high volume
+RAM:6907 RSB.Ratn       ; Rs232 B attention reason bit mask
+RAM:6908 RSB.RR0
+RAM:6909 RSB.RR1
+RAM:690A RSBIBuff:
+RAM:692C RSBOBuff:
+RAM:694E Sp.Ratn        ; Speech attention reason bit mask
+RAM:694F Sp.RR0
+RAM:6950 Sp.RR1
+RAM:6951 SpOBuff:
+RAM:6973 KBIBuff:       ; Input circular buffer for keyboard
+RAM:6995 Kriz.NVal:     ; Buffers next tablet msg to go to PERQ
+RAM:6999 Kriz.CVal:     ; Buffers current msg being received
+RAM:699D KrizState      ; State variable for current msg
+RAM:699E CurrTCB        ; Current Tasks TCB
+RAM:69A0 TCBBase:       ;   NTCBs * TCBSize space for all TCBS
+RAM:6A04 Stack1:        ; Stack area 1
+RAM:6A28 Stack2:        ; Stack area 2
+RAM:6A4C Stack3:        ; Stack area 3
+RAM:6A70 Stack4:        ; Stack area 4
+RAM:6A94 Stack5:        ; Stack area 5
+RAM:6AB8 Stack6:        ; Stack area 6
+RAM:6ADC Stack7:        ; Stack area 7      vvv conflict!?
+RAM:6ADC BufGPIB        ; Buffer for GPIB   ^^^ conflict?!
+RAM:72DC BufSIO:        ; Buffer for SIO
+RAM:7ADC BufFloppy:     ; Buffer for Floppy
+RAM:7CDB ; End of Data
+RAM:7FFF ;
 RAM:7FFF ; End of RAM

--- a/PERQemu/Program.cs
+++ b/PERQemu/Program.cs
@@ -90,8 +90,6 @@ namespace PERQemu
 
             // Set up command-line parser and GUI manager
             _cli = new CommandProcessor();
-
-            //_gui = new FormsManager();
             _gui = new EventLoop();
 
             // Create main objects

--- a/PERQemu/Program.cs
+++ b/PERQemu/Program.cs
@@ -123,7 +123,14 @@ namespace PERQemu
             // If the user requested a start-up script, read it now
             if (!string.IsNullOrEmpty(_switches.runScript))
             {
-                _cli.ReadScript(_switches.runScript);
+                try
+                {
+                    _cli.ReadScript(_switches.runScript);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Could not read startup script: {e.Message}");
+                }
             }
 
             // If the GUI is requested, start up the FrontPanel display

--- a/PERQemu/Properties/AssemblyInfo.cs
+++ b/PERQemu/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.5.5.0")]
-[assembly: AssemblyFileVersion("0.5.5.0")]
+[assembly: AssemblyVersion("0.5.6.0")]
+[assembly: AssemblyFileVersion("0.5.6.0")]

--- a/PERQemu/Properties/AssemblyInfo.cs
+++ b/PERQemu/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("0.5.6.0")]
-[assembly: AssemblyFileVersion("0.5.6.0")]
+[assembly: AssemblyVersion("0.5.8.0")]
+[assembly: AssemblyFileVersion("0.5.8.0")]

--- a/PERQemu/Readme-source.txt
+++ b/PERQemu/Readme-source.txt
@@ -49,12 +49,10 @@ could use yet another rewrite...]
 1.2  Version History
 --------------------
 
-The next release will incorporate expanded functionality while still primarily
-focused on PERQ-1 configurations: Ethernet and the Canon laser printer are the
-two major peripherals to be added, along with bug fixes and further refinements
-to the user interface.  Additionally, first steps have been taken to refactor
-the I/O section and Z80 to support the EIO and PERQ-2 configurations.  It is
-currently in development on the "experiments" branch as PERQemu v0.5.5.
+The next major release will incorporate expanded functionality as support for
+PERQ-2 configurations starts to come together.  The first steps have been taken
+to bring up the EIO board and new Z80 subsystem with larger/faster hard drives.
+This is currently in development on the "experiments" branch as PERQemu v0.5.6.
 
 PERQemu v0.5.5 is a feature release, rolling up fixes and features added since
 v0.5.0 (Canon, Ethernet).  This is a pre-release to the main branch only.
@@ -372,17 +370,18 @@ There are a bunch of Z80 devices:
 
     - The "Z80SIO" class emulates the Zilog SIO/2 chip used for RS-232,
       "speech", and the Kriz tablet.  The PERQ-1 has one SIO chip; the PERQ-2
-      EIO will have two.  The "Z80SIOChannel" class does the heavy lifting.
+      EIO has two.  The "Z80SIOChannel" class does the heavy lifting.
 
 Support for the EIO requires several new controller chips:
 
     - The "Oki5832" class implements the real-time clock (RTC) chip.  This
       battery-backed clock lets the PERQ set the time automatically at bootup;
 
-    - The "Am9519" class will handle the new interrupt controller for EIO;
-
+    - The "Am9519" class is the new interrupt controller for EIO, in a hybrid
+      arrangement with the two SIO chips;                    [Testing/debugging]
+      
     - New Intel i8237 (DMAC) and i8254 (PIT) chips replace the Zilog DMA and
-      CTC chips used on the original IOB.  [TBD]
+      CTC chips used on the original IOB.                          [In progress]
 
 
 2.3.2  Serial Devices
@@ -404,7 +403,7 @@ these into the Emulator/IO/SerialDevices folder.
       which use the SIO chip to transmit mouse coordinates;
 
     - "SerialKeyboard" will contain the driver for the PERQ-2's "VT100-style"
-      keyboard, attached to the EIO board;                 [Not yet implemented]
+      keyboard, attached to the EIO board;                             [Testing]
 
     - The "Speech" class will emulate the PERQ's CVSD chip to provide "telephone
       quality" (8Khz, mono) audio output.  This class will provide the glue to
@@ -457,10 +456,16 @@ Emulator/IO/DiskDevices:
       (the "Disk14Inch" class of drives) common to all PERQ-1 configurations.
       It works with the Z80's HardDiskSeek device to manage stepping the heads;
 
-    - The "MicropolisDiskController" class is in development.  This will
-      support the Micropolis 1200-series 8" hard disks that were originally
-      introduced with the PERQ-2 and PERQ-2/T1.  This will allow configuration
-      of drives in the "Disk8Inch" storage class;
+    - The "MicropolisDiskController" class is in development.  This supports
+      Micropolis 1200-series hard disks (Disk8Inch class) that were originally
+      introduced with the PERQ-2 and PERQ-2/T1.  This version works with the
+      EIO board only;
+
+    - The "CIOMicropolisDiskController" class may be revisited after the EIO
+      version is complete; this rare device may/will allow a PERQ-1 CIO board
+      attach an 8" drive, and is sufficiently different that it warrants its
+      own class.  Limited software support means this is low on the priority
+      list, as source code and schematics are unavailable;
 
     - The "MFMDiskController" and "SMDController" classes will someday provide
       support for Disk5Inch and DiskSMD devices (on PERQ-2 models).
@@ -745,6 +750,7 @@ PERQ info and lore.  More to come!
 
 Update history:
 
+v2.3 - 3/21/2024 - skeezics
 v2.2 - 2/18/2024 - skeezics - updated for the v0.5.5 interim release
 v2.1 - 3/8/2023 - skeezics
 v2.0 - 1/24/2023 - skeezics - corresponds to the merge for v0.5.0

--- a/PERQemu/Readme-source.txt
+++ b/PERQemu/Readme-source.txt
@@ -381,7 +381,11 @@ Support for the EIO requires several new controller chips:
       arrangement with the two SIO chips;                    [Testing/debugging]
       
     - New Intel i8237 (DMAC) and i8254 (PIT) chips replace the Zilog DMA and
-      CTC chips used on the original IOB.                          [In progress]
+      CTC chips used on the original IOB;                          [In progress]
+
+    - The "PERQDMA" class is a simulation of the EIO hardware that provides two
+      _more_ FIFOs between the PERQ DMA engine and the Z80 DMAC.  Seriously,
+      there are over 20 74S225s on this board!?                    [In progress]
 
 
 2.3.2  Serial Devices
@@ -468,7 +472,7 @@ Emulator/IO/DiskDevices:
       list, as source code and schematics are unavailable;
 
     - The "MFMDiskController" and "SMDController" classes will someday provide
-      support for Disk5Inch and DiskSMD devices (on PERQ-2 models).
+      support for Disk5Inch and DiskSMD devices (on PERQ-2/T2 and T4 models).
 
 Several tape drives will also be supported, but PERQemu does not yet emulate
 the controllers for these.  Tape media will be accessed through the PERQmedia
@@ -750,7 +754,7 @@ PERQ info and lore.  More to come!
 
 Update history:
 
-v2.3 - 3/21/2024 - skeezics
+v2.3 - 3/25/2024 - skeezics
 v2.2 - 2/18/2024 - skeezics - updated for the v0.5.5 interim release
 v2.1 - 3/8/2023 - skeezics
 v2.0 - 1/24/2023 - skeezics - corresponds to the merge for v0.5.0

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -161,8 +161,8 @@ There are several subdirectories:
 
     Output/
         When logging debug output to disk is enabled, log files go here by
-        default.  When screenshots and printing are implemented, that output
-        will land here too.  (Output directory is a settable preference.)
+        default.  Screenshots and Canon laser printer output is directed
+        here as well.  (Output directory is a settable preference.)
 
     PROM/
     Resources/
@@ -253,10 +253,11 @@ As of v0.4.6, these PERQ operating systems also boot:
 
 Fixed in v0.5.3:
   - A workaround for PNX 2 video support is included (disk image TBA).
+  - Accent S7 (Release III, unreleased) also verified as well.
 
 NOTE: PNX 1 drops into its microcode debugger (i.e., crashes) after booting if
 2MB of memory is configured; it runs fine with 1MB.  PNX 2, POS, MPOS and Accent
-have no trouble with a full megaword of memory.
+have no trouble with a full megaword (2MB) of memory.
 
 Accent mouse tracking takes a little getting used to since it runs in relative
 mode.  To simulate mouse "swipes" you have to use the Alt key (Option key on
@@ -357,8 +358,8 @@ The following hardware has been implemented in the emulator:
       but with caveats.  Check the User Guide for details.
 
   Canon:
-    - Laser printer interface provides high quality output in PNG or TIFF format
-      at 240- or 300-dpi.
+    - Laser printer interface can now be enabled as an OIO option.  It provides
+      high quality output in PNG or TIFF format at 240- or 300-dpi.
 
 
 There is a ton of additional detail about the internals of PERQemu itself in
@@ -423,7 +424,7 @@ window back onto the screen.  This was fixed?  Kind of?  Except when it isn't?
 Symptoms:  On Linux, reading data from a COM port (/dev/ttyS0) stalls unless
 output is transmitted (to prod the receiver).  Windows and Mac serial devices
 seem to struggle less, but this isn't exactly "production ready."  Flow control
-on all three plaltforms is unreliable and data may be garbled or lost.
+on all three platforms is unreliable and data may be garbled or lost.
 
 Workaround:  None, yet.  This is largely due to serious deficiencies in the
 C#/Mono System.IO.Ports.SerialPort implementation that will require a reworking

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -441,20 +441,22 @@ v1.0 - TBD
   - Working audio output :-)
 
 v0.9 - TBD
+  Fill in the final pieces:
+  - Expand available media library
+  - Full-featured Ethernet
+  - 24-bit "T4" model with larger memory
+
+v0.7 - TBD
   Leverage the new architecture to roll out new models, new peripherals and
   open up the full range of available operating systems!
   - PERQ-2 EIO emulation support: expanded IO Board with faster Z80, second
     serial port, RTC chip, support for two hard disks
   - PERQ-2 peripherals: 8" and 5.25" disk drives, VT100-style keyboard
-  - 24-bit "T4" model with larger memory
 
-v0.7 - TBD
-  Additional I/O Options once the baseline devices are complete:
-  - Ethernet!
-  - Expand available media library!
-  - (Progress toward) EIO/PERQ-2
+v0.5.6 - Experimental branch (ongoing)
+  - Progress toward EIO/PERQ-2
 
-v0.5.5 - Experimental branch (v0.7.0 pre-release)
+v0.5.5 - Main branch (v0.7.0 pre-release)
   - Ethernet running (but requires root/admin access)
   - Patch for Turkish keyboard in CLI
   - Limited Micropolis 8" disk support
@@ -577,6 +579,7 @@ v0.1 - First public release.
 
 Update history:
 
+3/21/2024 - skeezicsb - v0.5.6 (experimental)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -65,21 +65,20 @@ the Great Refactoring (v0.5.0 and beyond) the WinForms-based emulator could run
 only the PERQ-1 "old" Z80 with a single Shugart hard disk.  The emulation was
 fairly complete, but the options for OS and software to run were limited.
 
-While the v0.5.0 release is a major leap in functionality and the available
-software base has expanded greatly, it still only emulates PERQ-1 configurations.
-Work on the experimental branch now shifts to expanded emulation options, adding
-new peripheral support (Ethernet, laser printer) and bug fixes, plus some new UI
-features along the way.
+The v0.5.0 release was a major leap in functionality and the available software
+base expanded greatly, but it still only emulated PERQ-1 configurations.  Work
+on the experimental branch shifted to expanding emulation options, adding new
+peripheral support (Ethernet, laser printer), bug fixes, and new UI features.
 
-PERQemu v0.5.5 rolls up new Canon printer support and expanded (but still highly
-experimental!) Ethernet support.  It is an interim release to skeezicsb/main and
-won't be submitted for a merge into the master at this time.
+PERQemu v0.5.5 added Canon printer support and expanded experimental Ethernet
+support.  It was an interim release to skeezicsb/main and wasn't submitted for
+a merge into the master.
 
 PERQemu v0.5.8 introduces the first milestone in PERQ-2/EIO support, adding a
 Micropolis 8" disk driver and enough of the EIO/Z80 components to allow POS G,
 Accent S6 and PNX 2 and 3 to boot.  There are still a number of rough edges and
-missing pieces that this interim development snapshot is not yet reliable enough
-for daily use.
+missing pieces, but this interim development snapshot is reliable enough to let
+it into the wild for testing from skeezicsb/main.
 
 Full PERQ-2 and 2/Tx support is underway; see the (tentative) roadmap below.
 Please check back often for updates!
@@ -500,7 +499,10 @@ v0.7 - TBD
     serial port, RTC chip, support for two hard disks
   - PERQ-2 peripherals: 8" and 5.25" disk drives, VT100-style keyboard
 
-v0.5.8 - Experimental branch (ongoing)
+v0.6.0 - Experiments branch
+  - Start of MFM support for PERQ-2/Tx multiple hard disk support
+
+v0.5.8 - Main branch (v0.7.0 pre-release)
   - Micropolis 8" disk (high-level operation works!; low-level formatting
     support is incomplete/untested)
   - EIO Z80 ROM source code formatted for use with the debugger
@@ -632,7 +634,7 @@ v0.1 - First public release.
 
 Update history:
 
-5/25/2024 - skeezicsb - v0.5.8 (experiments)
+6/19/2024 - skeezicsb - v0.5.8 (main)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -314,7 +314,8 @@ The following hardware has been implemented in the emulator:
     - New register-level interface written to support Z80 DMA, CTC, SIO, FDC
       and GPIB controller chips;
     - Z80 Debugger support includes single stepping and source code display
-      (for the current v8.7 ROMs; v10.17 source disassembly in progress).
+      (for the current v8.7 ROMs; v100.017 source disassembly for EIO is now
+      complete, CIO in progress).
 
   Keyboard:
     - Now uses the SDL2 interface so no more horrible hacks required for MacOS;
@@ -579,7 +580,7 @@ v0.1 - First public release.
 
 Update history:
 
-3/25/2024 - skeezicsb - v0.5.6 (experiments)
+4/10/2024 - skeezicsb - v0.5.6 (experiments)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -579,12 +579,12 @@ v0.1 - First public release.
 
 Update history:
 
-3/21/2024 - skeezicsb - v0.5.6 (experimental)
+3/25/2024 - skeezicsb - v0.5.6 (experiments)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)
 12/28/2022 - skeezicsb - v0.4.8 (main)
-11/1/2022 - skeezicsb - v0.4.6 (experimental)
+11/1/2022 - skeezicsb - v0.4.6 (experiments)
 3/14/2019 - skeezicsb - v0.4.5beta (unreleased)
 6/24/2018 - skeezicsb - v0.4 - v0.4.4
 6/24/2010 - jdersch - v0.1 - v0.3

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -356,8 +356,7 @@ The following hardware has been implemented in the emulator:
       useful on POS F.1 and later (no support in D.6, F.0, PNX 1, or Accent S4);
     - The simulated Summagraphics BitPadOne works with the new GPIB; it is
       supported on all PERQ OSes;
-    - PERQ-2/EIO configuration support: Kriz tablet is working, GPIB BitPad is
-      the GPIB BitPad is still non-functional
+    - PERQ-2/EIO configuration support: Kriz tablet and GPIB BitPad are working.
 
   Ethernet:
     - A "null" bare-bones interface is now available when the "Ether" option for
@@ -457,7 +456,7 @@ test to fail when a 16K CPU is configured.  When the DDS stops at 142, type
 "debug jump $808" to resume execution, bypassing the failed test.  Note that the
 DDS status will be off for the remainder of the session, and will not stop at
 255 when PNX has completed booting.  A patch to detect and fix this has been
-developed and is available in PERQemu v0.5.8 and beyond.
+developed and is included in PERQemu v0.5.8 and beyond.
 
 
 5. PNX video glitches.
@@ -506,7 +505,8 @@ v0.5.8 - Experimental branch (ongoing)
   - EIO Z80 ROM source code formatted for use with the debugger
   - EIO Z80 peripherals added:  RTC chip, VT100-style keyboard, Am9519 IRQ
     control and i8237 DMAC
-  - Kriz tablet patched for EIO; PNX Vfy bug workaround devised
+  - Kriz tablet and GPIB updated for EIO; PNX Vfy bug workaround devised
+  - Ethernet drivers updated for EIO (no new functionality, yet)
 
 v0.5.5 - Main branch (v0.7.0 pre-release)
   - Ethernet running (but requires root/admin access)
@@ -631,7 +631,7 @@ v0.1 - First public release.
 
 Update history:
 
-5/20/2024 - skeezicsb - v0.5.8 (experiments)
+5/23/2024 - skeezicsb - v0.5.8 (experiments)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)

--- a/PERQemu/Readme.txt
+++ b/PERQemu/Readme.txt
@@ -265,6 +265,11 @@ Fixed in v0.5.3:
   - A workaround for PNX 2 video support is included (disk image TBA).
   - Accent S7 (Release III, unreleased) also verified as well.
 
+Added in v0.5.8:
+  - PNX 3 is now also confirmed to boot and run (from floppy) with an
+    included video patch.  (I may be missing one critical floppy needed
+    to complete a full hard disk install, however.  Watch this space.)
+
 
 NOTE: PNX 1 only supports 1MB of memory and will crash if configured with more.
 PNX 2, PNX 3, POS, MPOS and Accent have no trouble with a full megaword (2MB)
@@ -329,8 +334,8 @@ The following hardware has been implemented in the emulator:
 
   Keyboard:
     - Now uses the SDL2 interface so no more horrible hacks required for MacOS;
-    - Support for the VT100-style PERQ-2 keyboard is now included but can't be
-      tested until EIO support is complete.
+    - Support for the VT100-style PERQ-2 keyboard is now included and is working
+      (but is not fully tested and has some limitations);
     - Currently caps lock is problematic and can get out of sync with the host.
       This is a minor inconvenience but it's on the bug list.  [TODO: check if
       this is still the case under SDL2.]
@@ -354,7 +359,7 @@ The following hardware has been implemented in the emulator:
   Tablets:
     - The proprietary Kriz tablet works with the new SIO chip; it is only
       useful on POS F.1 and later (no support in D.6, F.0, PNX 1, or Accent S4);
-    - The simulated Summagraphics BitPadOne works with the new GPIB; it is
+    - The simulated Summagraphics BitPadOne works with the new GPIB and is
       supported on all PERQ OSes;
     - PERQ-2/EIO configuration support: Kriz tablet and GPIB BitPad are working.
 
@@ -461,18 +466,14 @@ developed and is included in PERQemu v0.5.8 and beyond.
 
 5. PNX video glitches.
 
-Symptoms: The PNX 2 window manager paints its stippled background with a strange
-striped pattern; PNX 3 does not seem to display anything after the VFY memory
-test, even though the DDS seems to indicate the system has booted.
+Symptoms: The PNX 2 window manager sometimes randomly paints its background 
+pattern with strange stripes or other visual anomalies.
 
-Workaround:  Under PNX 2, the strange background pattern is visually distracting
-but does not appear to cause any issues running the OS.  Sometimes dragging a
-window around will cause it to repaint properly.  When attempting to boot PNX 3,
-the LineCounter interrupt does not appear to fire and thus the screen does not
-repaint properly once PNX takes over control of the video display list.  If you
-can type "debug raise interrupt linecounter" on the console 60 times a second
-the display is properly refreshed.  (Yet Another PNX video patch will be added
-in a future snapshot as PNX 3 seems to add significant functionality!)
+Workaround:  While the odd background pattern is visually distracting it does
+not appear to cause any issues running the OS.  Sometimes dragging a window
+around will cause it to repaint properly.  Initial analysis shows that this
+might be a RasterOp glitch specific to the PNX 2 implementation, as it does not
+affect PNX 1 or other OSes.
 
 
 5.0 Version History and Roadmap
@@ -631,7 +632,7 @@ v0.1 - First public release.
 
 Update history:
 
-5/23/2024 - skeezicsb - v0.5.8 (experiments)
+5/25/2024 - skeezicsb - v0.5.8 (experiments)
 2/18/2024 - skeezicsb - v0.5.5 (main)
 1/24/2023 - jdersch - v0.5.0
 1/17/2023 - skeezicsb - v0.4.9 (main)

--- a/PERQemu/UI/Output/PNGFormatter.cs
+++ b/PERQemu/UI/Output/PNGFormatter.cs
@@ -74,9 +74,9 @@ namespace PERQemu.UI.Output
 
                 phys.ResetChecksum();
                 phys.Write(Encoding.ASCII.GetBytes("pHYs"), 0, 4);
-                phys.WriteUInt(ppm);    // X
-                phys.WriteUInt(ppm);    // Y
-                phys.WriteByte(1);      // Pixels per meter!
+                phys.WriteUInt(ppm);            // X
+                phys.WriteUInt(ppm);            // Y
+                phys.WriteByte(1);              // Pixels per meter!
                 crc = phys.WriteCRC;
             }
             fs.WriteUInt(crc);
@@ -116,7 +116,7 @@ namespace PERQemu.UI.Output
                 {
                     for (var i = 0; i < page.BitHeight; i++)
                     {
-                        cmp.WriteByte(0);   // Filter type 0
+                        cmp.WriteByte(0);       // Filter type 0
                         cmp.Write(page.Buffer, (int)(page.ScanWidth * i), (int)page.ScanWidth);
                     }
                 }

--- a/PERQemu/UI/SDL/Display.cs
+++ b/PERQemu/UI/SDL/Display.cs
@@ -448,7 +448,14 @@ namespace PERQemu.UI
             // Tell the EventLoop we're going away
             PERQemu.GUI.DetachDisplay();
 
-            // Clear the renderer
+            // Clear the display texture
+            if (_displayTexture != IntPtr.Zero)
+            {
+                SDL.SDL_DestroyTexture(_displayTexture);
+                _displayTexture = IntPtr.Zero;
+            }
+
+            // And the renderer
             if (_sdlRenderer != IntPtr.Zero)
             {
                 SDL.SDL_DestroyRenderer(_sdlRenderer);

--- a/PERQemu/UI/SDL/EventLoop.cs
+++ b/PERQemu/UI/SDL/EventLoop.cs
@@ -121,9 +121,7 @@ namespace PERQemu.UI
 
             // Adjust the timer for running the message loop.  It should be no
             // longer than 16.667ms if we're to maintain 60fps on the Display
-            HighResolutionTimer.Enable(_timerHandle, false);
             HighResolutionTimer.Adjust(_timerHandle, 15d);
-            HighResolutionTimer.Enable(_timerHandle, true);
         }
 
         /// <summary>
@@ -137,9 +135,7 @@ namespace PERQemu.UI
             _winStateChanged = false;
 
             // Pump the brakes
-            HighResolutionTimer.Enable(_timerHandle, false);
             HighResolutionTimer.Adjust(_timerHandle, 50d);
-            HighResolutionTimer.Enable(_timerHandle, true);
         }
 
         /// <summary>

--- a/PERQemu/UI/SDL/KeyboardMap.cs
+++ b/PERQemu/UI/SDL/KeyboardMap.cs
@@ -75,6 +75,8 @@ namespace PERQemu.UI
     {
         public KeyboardMap(ChassisType machine)
         {
+            _map = new Dictionary<SDL.SDL_Keycode, PERQKey>();
+
             if (machine == ChassisType.PERQ1)
                 SetupPERQ1Map();
             else
@@ -108,6 +110,12 @@ namespace PERQemu.UI
 
         public void SetKeyMapping(SDL.SDL_Keycode keycode, PERQKey key)
         {
+#if DEBUG
+            if (_map.ContainsKey(keycode))
+            {
+                Console.WriteLine($"Duplicate keycode {keycode} (key {key}) entered in map!");
+            }
+#endif
             _map[keycode] = key;
         }
 
@@ -279,7 +287,7 @@ namespace PERQemu.UI
             SetKeyMapping(SDL.SDL_Keycode.SDLK_TAB, new PERQKey(0xf6, 0xf6, 0x76, 0x76));        // TAB
             SetKeyMapping(SDL.SDL_Keycode.SDLK_ESCAPE, new PERQKey(0xe4, 0xe4, 0x64, 0x64));     // ESCAPE
             SetKeyMapping(SDL.SDL_Keycode.SDLK_INSERT, new PERQKey(0xe4, 0xe4, 0x64, 0x64));     // INSERT (same as ESC on PERQ)
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_DELETE, new PERQKey(0x80, 0x80, 0x00, 0x00));     // DELETE (ZERO? SRSLY?)
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_DELETE, new PERQKey(0x80, 0x80, 0xf4, 0xf4));     // DELETE (send SETUP, not NUL!)
             SetKeyMapping(SDL.SDL_Keycode.SDLK_RETURN, new PERQKey(0xf2, 0xf2, 0x72, 0x72));     // RETURN
 
             // Arrows
@@ -291,38 +299,45 @@ namespace PERQemu.UI
             // PERQ/VT100 keys
             SetKeyMapping(SDL.SDL_Keycode.SDLK_HELP, new PERQKey(0xf8, 0xf8, 0x78, 0x78));       // HELP
             SetKeyMapping(SDL.SDL_Keycode.SDLK_CLEAR, new PERQKey(0xea, 0xea, 0x6a, 0x6a));      // OOPS
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_SYSREQ, new PERQKey(0x7f, 0x7e, 0x7d, 0x7c));     // BREAK (Todo: Pause/Break?)
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_CLEAR, new PERQKey(0xea, 0xea, 0x6a, 0x6a));   // OOPS (Mac)
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_SYSREQ, new PERQKey(0x7f, 0x7e, 0x7d, 0x7c));     // BREAK
             SetKeyMapping(SDL.SDL_Keycode.SDLK_SCROLLLOCK, new PERQKey(0xf3, 0xf3, 0xf1, 0xf1)); // NOSCRL
             SetKeyMapping(SDL.SDL_Keycode.SDLK_PAGEDOWN, new PERQKey(0xf5, 0xf5, 0x75, 0x75));   // LINEFEED
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_PAGEUP, new PERQKey(0xf4, 0xf4, 0xf9, 0xf9));     // SETUP (Todo: SYSREQ better choice?)
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_PAGEUP, new PERQKey(0xf4, 0xf4, 0xf9, 0xf9));     // SETUP
 
             // Keypad
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_F1, new PERQKey(0x7b));         // PF1
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_F2, new PERQKey(0x7a));         // PF2
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_F3, new PERQKey(0x79));         // PF3
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_F4, new PERQKey(0x74));         // PF4
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_F1, new PERQKey(0x7b));          // PF1
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_F2, new PERQKey(0x7a));          // PF2
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_F3, new PERQKey(0x79));          // PF3
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_F4, new PERQKey(0x74));          // PF4
 
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_PERIOD, new PERQKey(0x6b));  // Keypad '.'
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_MINUS, new PERQKey(0x6c));   // Keypad '-'
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_COMMA, new PERQKey(0x6d));   // Keypad ','
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_ENTER, new PERQKey(0x73));   // ENTER
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_PERIOD, new PERQKey(0x6b));   // Keypad '.'
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_MINUS, new PERQKey(0x6c));    // Keypad '-'
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_COMMA, new PERQKey(0x6d));    // Keypad ','
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_ENTER, new PERQKey(0x73));    // ENTER
 
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_0, new PERQKey(0x69));       // NumPad 0
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_1, new PERQKey(0x68));       // NumPad 1
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_2, new PERQKey(0x67));       // NumPad 2
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_3, new PERQKey(0x66));       // NumPad 3
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_4, new PERQKey(0x65));       // NumPad 4
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_5, new PERQKey(0x63));       // NumPad 5
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_6, new PERQKey(0x62));       // NumPad 6
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_7, new PERQKey(0x61));       // NumPad 7
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_8, new PERQKey(0x60));       // NumPad 8
-            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_9, new PERQKey(0x5f));       // NumPad 9
+            // Not present on PERQ, map to expected key on modern keyboards:
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_PLUS, new PERQKey(0xd4));     // '+'
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_EQUALS, new PERQKey(0xc2));   // '='
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_DIVIDE, new PERQKey(0xd0));   // '/'
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_MULTIPLY, new PERQKey(0xd5)); // '*'
+
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_0, new PERQKey(0x69));        // NumPad 0
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_1, new PERQKey(0x68));        // NumPad 1
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_2, new PERQKey(0x67));        // NumPad 2
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_3, new PERQKey(0x66));        // NumPad 3
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_4, new PERQKey(0x65));        // NumPad 4
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_5, new PERQKey(0x63));        // NumPad 5
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_6, new PERQKey(0x62));        // NumPad 6
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_7, new PERQKey(0x61));        // NumPad 7
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_8, new PERQKey(0x60));        // NumPad 8
+            SetKeyMapping(SDL.SDL_Keycode.SDLK_KP_9, new PERQKey(0x5f));        // NumPad 9
 
             Log.Debug(Category.Keyboard, "PERQ-2 (VT100) map initialized");
         }
 
         // One map to rule them all
-        Dictionary<SDL.SDL_Keycode, PERQKey> _map = new Dictionary<SDL.SDL_Keycode, PERQKey>();
+        Dictionary<SDL.SDL_Keycode, PERQKey> _map;
 
         // Have to catch/test for CAPS LOCK status ourselves, and maintain local state.  Ugh.
         bool _lockCaps;


### PR DESCRIPTION
Snapshot of PERQ-2/EIO developments for the v0.5.8 preview release.  Adds 8" Micropolis hard disk support and enough of the new EIO Z80 to run several OS releases.  This is a very early (but functional) preview of the next milestone release (tentatively slated to be v0.7.0) which will enable all PERQ-2 models to be emulated.